### PR TITLE
Internal: add `UIView.pinToSuperview`

### DIFF
--- a/Sources/SATSCore/Extensions/UIKit/UIView-Layout.swift
+++ b/Sources/SATSCore/Extensions/UIKit/UIView-Layout.swift
@@ -8,6 +8,11 @@ public extension UIView {
         translatesAutoresizingMaskIntoConstraints = !withAutoLayout
     }
 
+    func pinToSuperview() {
+        guard let superview = superview else { return }
+        pin(to: superview)
+    }
+
     func pin(to view: UIView, preserveMargins: Bool = false, includeSafeArea: Bool = false) {
         if preserveMargins {
             NSLayoutConstraint.activate([


### PR DESCRIPTION
We still have `UIView.pin(to: _)`

but in many cases we just want to pin to the superview, then
if we just call `pinToSuperview`, we don't need to change the parameter
of `pin(to:)` when that superview changes