### PR TITLE
Internal: Add pipeline to run tests in azure

### DIFF
--- a/azure-devops/azure-pipelines-test.yml
+++ b/azure-devops/azure-pipelines-test.yml
@@ -1,5 +1,10 @@
+trigger: none
+
 pr:
-- main
+  autoCancel: true
+  branches:
+    include:
+      - main
 
 variables:
   - group: "SatsVariables"
@@ -7,6 +12,8 @@ variables:
     value: "DemoApp"
   - name: "sdk"
     value: "iphoneos"
+  - name: "iOSVersion"
+    value: "14.4"
 
 pool:
   vmImage: "macos-latest"
@@ -14,7 +21,7 @@ pool:
 jobs:
   - job: BuildDev
     displayName: Build SATS Dev
-    steps:          
+    steps:
       - task: Xcode@5
         displayName: "Xcode Test"
         inputs:
@@ -27,7 +34,7 @@ jobs:
           signingOption: "auto"
           args: "-UseModernBuildSystem=YES"
           destinationPlatformOption: "iOS"
-          destinationSimulators: "iPhone 12 Pro,OS=14.4"
+          destinationSimulators: "iPhone 12 Pro,OS=$(iOSVersion)"
           workingDirectory: "DemoApp"
           useXcpretty: true
           publishJUnitResults: true


### PR DESCRIPTION
I created a new pipeline to run the tests when we create PRs.

This runs the tests from the DemoApp, which per-scheme configuration also include the tests for the SATSCore package.

Then, we can have extra tests in the DemoApp (like SnapshotTest for the DemoScreens) as part of the test coverage for the package