### PR TITLE
Fix: missing color

### DIFF
--- a/Sources/SATSCore/Assets/Colors.xcassets/On/gradient/onGradientDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/gradient/onGradientDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
This is an interesting bug/fix.

the problem is that the asset color lives in `onGradientDIsabled/Content.json` which I committed at some point and pushed to GitHub.

Then, the test were not run in the repo as #19 is not yet finished, so the test didn't fail.
But also, I fixed this in my local repo, but *since it's a folder whose name case changed, that wasn't picked up in Git*???

So I removed and added the color and you can see now the file changed location