### PR TITLE
Fix: update GradientView colors when the traits change

### DIFF
--- a/Sources/SATSCore/Components/GradientView/GradientView.swift
+++ b/Sources/SATSCore/Components/GradientView/GradientView.swift
@@ -3,9 +3,7 @@ import UIKit
 /// Implements a semi-translucent fog aka gradient for the ProfileTrainingGraphCell
 public class GradientView: UIView {
     public var colors: [UIColor] = [] {
-        didSet {
-            gradientLayer.colors = colors.map { $0.cgColor }
-        }
+        didSet { updateColors() }
     }
 
     public var startPoint: CGPoint {
@@ -32,5 +30,14 @@ public class GradientView: UIView {
 
     public override class var layerClass: AnyClass {
         CAGradientLayer.self
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateColors()
+    }
+
+    private func updateColors() {
+        gradientLayer.colors = colors.map { $0.cgColor }
     }
 }


### PR DESCRIPTION
So if we go from dark to light mode, we update the colors, as `cgColors` are
computed once, so if we change to dark mode the `cgColor` needs to be
re-computed to reflect the dark mode color
