### PR TITLE
Use fixed version of SATSType as a dependency

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SATSType",
         "repositoryURL": "git@github.com:healthfitnessnordic/SATSType-iOS.git",
         "state": {
-          "branch": "main",
+          "branch": null,
           "revision": "0a8f4d295169febbce9b99485589b03314b4bb15",
-          "version": null
+          "version": "0.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "SATSType", url: "git@github.com:healthfitnessnordic/SATSType-iOS.git", .branch("main")),
+        .package(
+            name: "SATSType",
+            url: "git@github.com:healthfitnessnordic/SATSType-iOS.git",
+            .upToNextMajor(from: "0.0.1")
+        ),
     ],
     targets: [
         .target(


### PR DESCRIPTION
For some reason SPM wasn't able to resolve in the main app when the package
version was depending on the main branch of SATSType