### PR TITLE
Enable automatic font scaling when user changes content size category

### DIFF
--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
@@ -11,6 +11,7 @@ public class SATSButton: UIButton {
         super.init(frame: .zero)
 
         self.translatesAutoresizingMaskIntoConstraints = !withAutoLayout
+        self.titleLabel?.adjustsFontForContentSizeCategory = true
         setup()
     }
 

--- a/Sources/SATSCore/BasicComponents/SATSLabel/SATSLabel.swift
+++ b/Sources/SATSCore/BasicComponents/SATSLabel/SATSLabel.swift
@@ -18,6 +18,7 @@ public class SATSLabel: UILabel {
         self.font = SATSFont.font(style: style, weight: weight)
         self.textColor = .onBackgroundPrimary
         self.translatesAutoresizingMaskIntoConstraints = !withAutoLayout
+        self.adjustsFontForContentSizeCategory = true
     }
 
     public required init?(coder: NSCoder) {


### PR DESCRIPTION
According to apples [documentation](https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/1771731-adjustsfontforcontentsizecategor), we need to set the ** adjustsFontForContentSizeCategory** to true, so that our labels automatically adjust to the new content size category selected by the user. When false, the user needs to restart the app for the scaling to take effect. So I think it makes sense to have this set to default true.