### PR TITLE
Improvement: update colors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SATSType",
+        "repositoryURL": "git@github.com:healthfitnessnordic/SATSType-iOS.git",
+        "state": {
+          "branch": null,
+          "revision": "0a8f4d295169febbce9b99485589b03314b4bb15",
+          "version": "0.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/Main/CTA/ctaDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Main/CTA/ctaDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xED",
-          "green" : "0xE8",
-          "red" : "0xE4"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF6",
-          "green" : "0xF5",
-          "red" : "0xF3"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xEC",
-          "green" : "0xE9",
-          "red" : "0xE8"
+          "blue" : "0xF6",
+          "green" : "0xF5",
+          "red" : "0xF3"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onClean.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onClean.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.129",
+          "red" : "0.055"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onCleanDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onCleanDisabled.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.451",
+          "green" : "0.408",
+          "red" : "0.369"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/Signal/signalWarning.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Signal/signalWarning.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x48",
-          "green" : "0xB2",
-          "red" : "0xDC"
+          "blue" : "0x00",
+          "green" : "0x6A",
+          "red" : "0x94"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x65",
-          "green" : "0x65",
-          "red" : "0x65"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Primary/goldPrimaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Primary/goldPrimaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.416",
-          "red" : "0.376"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Primary/platinumPrimaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Primary/platinumPrimaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.416",
-          "red" : "0.376"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Primary/silverPrimaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Primary/silverPrimaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.416",
-          "red" : "0.376"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
@@ -48,8 +48,8 @@ public extension SATSButton.Style {
 
     static let clean = SATSButton.Style(
         name: "Clean",
-        titleColor: .onSecondary,
-        titleColorDisabled: .onSecondaryDisabled,
+        titleColor: .onClean,
+        titleColorDisabled: .onCleanDisabled,
         backgroundColor: .clean,
         backgroundColorHighlighted: .secondaryHighlight,
         backgroundColorDisabled: .secondaryDisabled

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
@@ -84,7 +84,7 @@ public class SATSButton: UIButton {
     private func updateSize() {
         contentEdgeInsets = size.adjustContentInsets(with: contentSpacing)
         imageEdgeInsets = size.imageEdgeInsets
-        titleEdgeInsets = UIEdgeInsets(top: 0, left: contentSpacing, bottom: 0, right: -contentSpacing)
+        titleEdgeInsets = UIEdgeInsets(vertical: 0, horizontal: contentSpacing)
 
         setContentHuggingPriority(size.contentHuggingPriority, for: .horizontal)
         setContentHuggingPriority(size.contentHuggingPriority, for: .vertical)

--- a/Sources/SATSCore/DNA/Colors/ColorName.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorName.swift
@@ -36,6 +36,9 @@ enum ColorName: String, CaseIterable {
     case onSecondary
     case onSecondaryDisabled
 
+    case onClean
+    case onCleanDisabled
+
     case onCta
     case onCtaDisabled
 

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -52,6 +52,9 @@ public extension Color {
     static var onSecondary: Color { color(.onSecondary) }
     static var onSecondaryDisabled: Color { color(.onSecondaryDisabled) }
 
+    static var onClean: Color { color(.onClean) }
+    static var onCleanDisabled: Color { color(.onCleanDisabled) }
+
     static var onCta: Color { color(.onCta) }
     static var onCtaDisabled: Color { color(.onCtaDisabled) }
 

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -49,6 +49,9 @@ public extension UIColor {
     static var onSecondary: UIColor { color(.onSecondary) }
     static var onSecondaryDisabled: UIColor { color(.onSecondaryDisabled) }
 
+    static var onClean: UIColor { color(.onClean) }
+    static var onCleanDisabled: UIColor { color(.onCleanDisabled) }
+
     static var onCta: UIColor { color(.onCta) }
     static var onCtaDisabled: UIColor { color(.onCtaDisabled) }
 

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -51,6 +51,8 @@ class ColorsTests: XCTestCase {
             .onPrimaryDisabled,
             .onSecondary,
             .onSecondaryDisabled,
+            .onClean,
+            .onCleanDisabled,
             .onCta,
             .onCtaDisabled,
             .onNonText,


### PR DESCRIPTION
- Add `.onClean` and `.onCleanDisabled` colors
- Update signal warning to '#946A00'
- Set disabled colors to `#E8E9EC`  as specified in Figma
- Use `.onClean` colors in the `.clean` buttons style