### PR TITLE
Component: ErrorView

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9B2BFBDC25B719AD00383193 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDB25B719AD00383193 /* ContentView.swift */; };
 		9B2BFBDE25B719AD00383193 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDD25B719AD00383193 /* Assets.xcassets */; };
 		9B2BFBE125B719AD00383193 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBE025B719AD00383193 /* Preview Assets.xcassets */; };
+		9B2E8065266649E4000A657D /* ErrorDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E8064266649E4000A657D /* ErrorDemoView.swift */; };
 		9B4083BD261DE66D00A3A718 /* TopBarDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4083B8261DE66D00A3A718 /* TopBarDemoView.swift */; };
 		9B4083BE261DE66D00A3A718 /* ExternalUrlDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4083BA261DE66D00A3A718 /* ExternalUrlDemoView.swift */; };
 		9B4083BF261DE66D00A3A718 /* ArticlePageViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4083BC261DE66D00A3A718 /* ArticlePageViewDemo.swift */; };
@@ -45,6 +46,7 @@
 		9B2BFBE025B719AD00383193 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9B2BFBE225B719AD00383193 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B2BFBF125B71A2800383193 /* SatsCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SatsCore; path = ..; sourceTree = "<group>"; };
+		9B2E8064266649E4000A657D /* ErrorDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDemoView.swift; sourceTree = "<group>"; };
 		9B4083B8261DE66D00A3A718 /* TopBarDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBarDemoView.swift; sourceTree = "<group>"; };
 		9B4083BA261DE66D00A3A718 /* ExternalUrlDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExternalUrlDemoView.swift; sourceTree = "<group>"; };
 		9B4083BC261DE66D00A3A718 /* ArticlePageViewDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticlePageViewDemo.swift; sourceTree = "<group>"; };
@@ -172,6 +174,14 @@
 			path = BasicComponents;
 			sourceTree = "<group>";
 		};
+		9B2E8063266649D8000A657D /* ErrorView */ = {
+			isa = PBXGroup;
+			children = (
+				9B2E8064266649E4000A657D /* ErrorDemoView.swift */,
+			);
+			path = ErrorView;
+			sourceTree = "<group>";
+		};
 		9B4083B7261DE66D00A3A718 /* TopBarView */ = {
 			isa = PBXGroup;
 			children = (
@@ -269,12 +279,13 @@
 			isa = PBXGroup;
 			children = (
 				9B4083BB261DE66D00A3A718 /* ArticlePageView */,
+				9B75EC43264B1D3C00B160EF /* EmptyStateView */,
+				9B2E8063266649D8000A657D /* ErrorView */,
 				9B4083B9261DE66D00A3A718 /* ExternalUrlView */,
 				9B9D6D91261EF6E300450E67 /* GradientView */,
 				9BCEE85626035CB2001C8692 /* InlineNoticeView */,
 				9BCEE85826035CB2001C8692 /* ProgressLineView */,
 				2865CF58261EDB9A00D6433F /* RoundLoadingView */,
-				9B75EC43264B1D3C00B160EF /* EmptyStateView */,
 				9B4083B7261DE66D00A3A718 /* TopBarView */,
 			);
 			path = Components;
@@ -399,6 +410,7 @@
 				9B4083BD261DE66D00A3A718 /* TopBarDemoView.swift in Sources */,
 				9BCEE85B26035CB2001C8692 /* ProgressLineDemoView.swift in Sources */,
 				9B7A4D6125D2B9C30086EA4F /* TreatmentsDemoView.swift in Sources */,
+				9B2E8065266649E4000A657D /* ErrorDemoView.swift in Sources */,
 				2865CF5A261EDB9A00D6433F /* RoundLoadingDemoView.swift in Sources */,
 				9B7A4D5E25D2B42C0086EA4F /* UIKitDemoView.swift in Sources */,
 				9BCEE85A26035CB2001C8692 /* InlineNoticeDemoView.swift in Sources */,

--- a/DemoApp/DemoApp/Views/Components/ErrorView/ErrorDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/ErrorView/ErrorDemoView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct ErrorDemoView: View {
+    var errorContainer: UIView {
+        let containerView = UIView()
+        containerView.backgroundColor = .backgroundPrimary
+
+        let errorView = ErrorView(withAutoLayout: true)
+        errorView.configure(
+            with: .init(
+                title: "Ooops!",
+                message: "Something went terribly wrong",
+                canRetry: true
+            )
+        )
+
+        containerView.addSubview(errorView)
+        errorView.pinToSuperview()
+
+        return containerView
+    }
+
+    var body: some View {
+        DemoWrapperView(view: errorContainer)
+            .navigationTitle("ErrorView")
+    }
+}
+
+struct ErrorDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ErrorDemoView()
+
+            ErrorDemoView()
+                .colorScheme(.dark)
+        }
+    }
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -17,8 +17,9 @@ struct ContentView: View {
 
                 Section(header: Text("Components")) {
                     NavigationLink("ArticlePageView", destination: ArticlePageViewDemo())
-                    NavigationLink("ExternalUrlView", destination: ExternalUrlDemoView())
                     NavigationLink("EmptyStateView", destination: EmptyStateDemoView())
+                    NavigationLink("ErrorView", destination: ErrorDemoView())
+                    NavigationLink("ExternalUrlView", destination: ExternalUrlDemoView())
                     NavigationLink("GradientView", destination: GradientDemoView())
                     NavigationLink("InlineNoticeView", destination: InlineNoticeDemoView())
                     NavigationLink("ProgressLineView", destination: ProgressLineDemoView())

--- a/Sources/SATSCore/Components/ErrorView/ErrorView.swift
+++ b/Sources/SATSCore/Components/ErrorView/ErrorView.swift
@@ -1,0 +1,115 @@
+import UIKit
+
+private extension SATSButton.Style {
+    static let error = SATSButton.Style(
+        name: "Error",
+        titleColor: .onSignal,
+        titleColorDisabled: .onPrimaryDisabled,
+        backgroundColor: .signalError,
+        backgroundColorHighlighted: UIColor.signalError.withAlphaComponent(0.8),
+        backgroundColorDisabled: .primaryDisabled
+    )
+}
+
+public struct ErrorViewData {
+    public let title: String?
+    public let message: String
+    public let canRetry: Bool
+
+    /// Data to present the error
+    /// - Parameters:
+    ///   - title: (optional) title
+    ///   - message: what went wrong
+    ///   - canRetry: (default `true`). If this value is true a "retry" button will be shown.
+    ///               The behavior of that button is controlled by the `ErrorView.onRetry` property
+    public init(title: String? = nil, message: String, canRetry: Bool = true) {
+        self.title = title
+        self.message = message
+        self.canRetry = canRetry
+    }
+}
+
+/// A view which displays a title, message and retry button
+public class ErrorView: UIView {
+    // MARK: Public properties
+
+    public var onRetry: (() -> Void) = {}
+
+    // MARK: Private properties
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(withAutoLayout: true)
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 12
+        return stackView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = SATSLabel(style: .section, weight: .emphasis)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var messageLabel: UILabel = {
+        let label = SATSLabel(style: .basic)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var retryButton: SATSButton = {
+        let button = SATSButton(style: .error)
+        button.setTitle(NSLocalizedString("Retry", comment: "Error screen retry button"), for: .normal)
+        button.layoutMargins = UIEdgeInsets(top: 5, horizontal: 45, bottom: 0)
+        button.addTarget(self, action: #selector(retryButtonDidTap), for: .touchUpInside)
+        return button
+    }()
+
+    // MARK: Initializers
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Public methods
+
+    public func configure(with errorData: ErrorViewData) {
+        if let title = errorData.title {
+            titleLabel.text = title
+            titleLabel.isHidden = false
+        } else {
+            titleLabel.isHidden = true
+        }
+
+        messageLabel.text = errorData.message
+        retryButton.isHidden = !errorData.canRetry
+    }
+
+    // MARK: Private methods
+
+    private func setup() {
+        [
+            titleLabel,
+            messageLabel,
+            retryButton,
+        ].forEach(stackView.addArrangedSubview(_:))
+
+        addSubview(stackView)
+
+        stackView.centerAndConstraintInSuperview()
+        NSLayoutConstraint.activate([
+            stackView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.8),
+        ])
+    }
+
+    @objc private func retryButtonDidTap() {
+        onRetry()
+    }
+}


### PR DESCRIPTION
I moved the ErrorView from the app to SATSCore as it should live in here.

I did some changes to the original API of it and the internal implementation.

In relation to the previous API, the changes are:

- No `compactLayout` option. This is not necessary as this view will take the
  size of the parent, so it can be full screen or whitin a smaller module.
- Use `configure(with:)` instead of `configure(title:message)`. The main reason
  for this is that we also have a `canRetry` boolean, with a default value of
  `true`.

  What we want here is that whenever `canRetry` is `true` the view will show a
  "Retry" button.
- Change `retryTapped: (() -> Void)?` to `onRetry: (() -> Void) = {}`. This
  delegate-like method has a default empty implementation. Previously we used
  the optionality of this property to decide to show the "Retry" button or not.

  Then even though the method was implemented, for particular errors we don't
  really want to allow to retry. For example: the backend got a bug causing a 500
  error. Retry-ing in a very short time won't accomplish anything, then we can
  have a finer control on when the user should be allowed to retry the action.
