### PR TITLE
Internal: bump SATSCore to iOS 13+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SATSCore",
-    platforms: [.iOS(.v12), .tvOS(.v14)],
+    platforms: [.iOS(.v13), .tvOS(.v14)],
     products: [
         .library(
             name: "SATSCore",

--- a/Sources/SATSCore/Components/LoadingView/LoadingView.swift
+++ b/Sources/SATSCore/Components/LoadingView/LoadingView.swift
@@ -9,11 +9,7 @@ public class LoadingView: UIView {
 
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView(withAutoLayout: true)
-        if #available(iOS 13.0, *) {
-            activityIndicator.style = .medium
-        } else {
-            activityIndicator.style = .gray
-        }
+        activityIndicator.style = .medium
         return activityIndicator
     }()
 

--- a/Sources/SATSCore/DNA/Colors/ColorTheme-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorTheme-SwiftUI.swift
@@ -6,7 +6,6 @@ public struct ColorThemeEnvironmentKey: EnvironmentKey {
     public static let defaultValue: ColorTheme = ColorTheme.current
 }
 
-@available(iOS 13.0, *)
 public extension EnvironmentValues {
     var colorTheme: ColorTheme {
         get { return self[ColorThemeEnvironmentKey] }

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 public extension Color {
 
     // MARK: Background

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 public extension View {
     @inlinable func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> some View {
         self.font(Font(SATSFont.font(style: style, weight: weight)))
     }
 }
 
-@available(iOS 13.0, *)
 public extension Text {
     func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> Text {
         self.font(Font(SATSFont.font(style: style, weight: weight)))

--- a/Sources/SATSCore/DNA/Icons/SwiftUI-Icon.swift
+++ b/Sources/SATSCore/DNA/Icons/SwiftUI-Icon.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension Image {
     static var back: Image { icon(.back) }
     static var close: Image { icon(.close) }

--- a/Sources/SATSCore/Extensions/SwiftUI/Representable/ShareSheet.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Representable/ShareSheet.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 public struct ShareSheet: UIViewControllerRepresentable {
     public typealias Callback = (
         _ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?

--- a/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleRepresentable.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleRepresentable.swift
@@ -17,7 +17,7 @@ import SwiftUI
     }
     ```
 */
-@available(iOS 13.0, *) public struct SimpleRepresentable<View: UIView>: UIViewRepresentable {
+public struct SimpleRepresentable<View: UIView>: UIViewRepresentable {
     let onCreation: (View) -> Void
 
     public init(onCreation: @escaping (View) -> Void) {

--- a/Sources/SATSCore/Extensions/SwiftUI/View-ConditionalModifier.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/View-ConditionalModifier.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 public extension View {
     /// Applies the given transform if the given condition evaluates to `true`.
     ///


### PR DESCRIPTION
As we did with the main app. Now we don't need to keep supporting iOS 12
anymore.
