### PR TITLE
Feature: `CustomAsyncImage` component

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		9B7C575D25B875C500A3C9A7 /* SATSLabelDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7C575C25B875C500A3C9A7 /* SATSLabelDemoView.swift */; };
 		9B7C576125B876C400A3C9A7 /* DemoWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7C576025B876C400A3C9A7 /* DemoWrapperView.swift */; };
 		9B86614725CD7AB40040F8CA /* ColorDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B86614625CD7AB40040F8CA /* ColorDemoView.swift */; };
+		9B9A53A0267CC51500AE9266 /* CustomAsyncImageDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9A539F267CC51400AE9266 /* CustomAsyncImageDemoView.swift */; };
 		9B9D6D94261EF70500450E67 /* GradientDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9D6D93261EF70500450E67 /* GradientDemoView.swift */; };
 		9BA17B1026666D3600BDAA9C /* LoadingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA17B0F26666D3600BDAA9C /* LoadingDemoView.swift */; };
 		9BB6E2AA25CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6E2A925CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift */; };
@@ -63,6 +64,7 @@
 		9B7C575C25B875C500A3C9A7 /* SATSLabelDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATSLabelDemoView.swift; sourceTree = "<group>"; };
 		9B7C576025B876C400A3C9A7 /* DemoWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoWrapperView.swift; sourceTree = "<group>"; };
 		9B86614625CD7AB40040F8CA /* ColorDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDemoView.swift; sourceTree = "<group>"; };
+		9B9A539F267CC51400AE9266 /* CustomAsyncImageDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAsyncImageDemoView.swift; sourceTree = "<group>"; };
 		9B9D6D93261EF70500450E67 /* GradientDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientDemoView.swift; sourceTree = "<group>"; };
 		9BA17B0F26666D3600BDAA9C /* LoadingDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingDemoView.swift; sourceTree = "<group>"; };
 		9BB6E2A925CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIFontsDemoView.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				9BF8D1F82679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift */,
 				9B7C575C25B875C500A3C9A7 /* SATSLabelDemoView.swift */,
 				9BFEDCC825CC1F780010A3F6 /* SATSButtonDemoView.swift */,
+				9B9A539F267CC51400AE9266 /* CustomAsyncImageDemoView.swift */,
 			);
 			path = BasicComponents;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				9B4083BE261DE66D00A3A718 /* ExternalUrlDemoView.swift in Sources */,
 				9BF8D1F92679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift in Sources */,
 				9BA17B1026666D3600BDAA9C /* LoadingDemoView.swift in Sources */,
+				9B9A53A0267CC51500AE9266 /* CustomAsyncImageDemoView.swift in Sources */,
 				9B4083BD261DE66D00A3A718 /* TopBarDemoView.swift in Sources */,
 				9BCEE85B26035CB2001C8692 /* ProgressLineDemoView.swift in Sources */,
 				9B7A4D6125D2B9C30086EA4F /* TreatmentsDemoView.swift in Sources */,

--- a/DemoApp/DemoApp/App/DemoAppApp.swift
+++ b/DemoApp/DemoApp/App/DemoAppApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @main
 struct DemoAppApp: App {
     init() {
-        SATSFont.registerCustomFonts()
+        Config.setup()
     }
 
     var body: some Scene {

--- a/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct CustomAsyncDemoView: View {
+    static let sampleImageUrl = URL(
+        string: "https://slothconservation.org/wp-content/uploads/2019/10/IMG_0400-820x1024.jpg"
+    )!
+    static let sampleImage = Image("treatmentsCover")
+
+    @State var imageViewData: ImageViewData = .image(Self.sampleImage)
+    @State var showControls: Bool = true
+
+    var body: some View {
+        VStack {
+            Spacer()
+
+            CustomAsyncImage(imageViewData) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 200, height: 200)
+                    .background(Color.red)
+            }
+            .background(Color.blue)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Custom Async Image")
+        .overlay(controls)
+        .background(Color.backgroundPrimary.ignoresSafeArea())
+    }
+
+    var controls: some View {
+        Group {
+            if showControls {
+                VStack {
+                    Spacer()
+
+                    Picker("State", selection: $imageViewData) {
+                        Text("Empty").tag(ImageViewData.empty)
+                        Text("Remote URL").tag(ImageViewData.remote(url: Self.sampleImageUrl))
+                        Text("Loading").tag(ImageViewData.loading)
+                        Text("Image").tag(ImageViewData.image(Self.sampleImage))
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+                .padding(.horizontal)
+            } else {
+                EmptyView()
+            }
+        }
+    }
+}
+
+struct CustomAsyncDemoView_Previews: PreviewProvider {
+    static func demoView(_ state: ImageViewData, showControls: Bool = false) -> some View {
+        CustomAsyncDemoView(imageViewData: state, showControls: showControls)
+    }
+
+    static var previews: some View {
+        Group {
+            NavigationView {
+                demoView(.remote(url: CustomAsyncDemoView.sampleImageUrl), showControls: true)
+            }
+            .previewDisplayName("Demo version")
+
+            Group {
+                demoView(.remote(url: CustomAsyncDemoView.sampleImageUrl))
+                    .previewDisplayName("Live URL view")
+
+                demoView(.empty)
+                    .previewDisplayName("Empty State")
+
+                demoView(.loading)
+                    .previewDisplayName("Loading State")
+
+                demoView(.image(CustomAsyncDemoView.sampleImage))
+                    .previewDisplayName("Fixed Image")
+            }
+            .previewLayout(.fixed(width: 300, height: 300))
+        }
+    }
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
 
                 Section(header: Text("SwiftUI Basics")) {
                     NavigationLink("Button Styles", destination: SATSButtonSwftUIDemoView())
+                    NavigationLink("Custom Async Image", destination: CustomAsyncDemoView())
                 }
 
                 Section(header: Text("Components")) {

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ import SATSCore
 In `AppDelegate` you should call
 
 ```swift
-SATSFont.registerCustomFonts()
+Config.setup()
 ```
+
+This will register the custom fonts and can be used to customize library options.
 
 ### UIKit
 

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/** Custom implementation of the `AsyncImage` view from iOS 15
+ We took inspiration from that implementation to make a custom one for us.
+
+ This component works together with `ImageViewData` to implement the
+ logic to render remote images.
+
+ One big advantage is that we can control the placeholder/loading state and
+ also pass a concrete image for testing purposes
+
+ ## Example
+
+ ```
+ CustomAsyncImage(.remote(url: url)) { image in
+     image
+         .resizable()
+         .aspectRatio(contentMode: .fit)
+         .frame(width: 200, height: 200)
+         .background(Color.red)
+ }
+ ```
+ */
+@available(iOS 14.0, *) public struct CustomAsyncImage<Output: View>: View {
+    @StateObject var viewModel: ImageViewModel
+    let transform: ((Image) -> Output)?
+
+    /// - Parameters:
+    ///   - state: the initial state for the async image
+    ///   - transform: a closure that will be used to add modifiers to the view
+    public init(_ state: ImageViewData, transform: ((Image) -> Output)? = nil) {
+        self._viewModel = StateObject(wrappedValue: ImageViewModel(state: state))
+        self.transform = transform
+    }
+
+    public var body: some View {
+        switch viewModel.state {
+        case .empty:
+            placeholder
+        case .remote:
+            placeholder
+                .onAppear(perform: viewModel.loadImage)
+        case .loading:
+            placeholder
+                .overlay(ProgressView())
+        case let .image(image):
+            if let transform = transform {
+                transform(image)
+            } else {
+                image
+            }
+        }
+    }
+
+    var placeholder: some View {
+        Rectangle()
+            .foregroundColor(.shimmer)
+    }
+}
+
+@available(iOS 14.0, *)
+public extension CustomAsyncImage where Output == Image {
+    init(_ state: ImageViewData) {
+        self.init(state, transform: nil)
+    }
+}

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -66,6 +66,7 @@ public struct CustomAsyncImage<Output: View>: View {
                 SimpleRepresentable<RoundLoadingView> { view in
                     view.startAnimating()
                 }
+                .frame(width: 16, height: 16)
             }
         }
     }

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -21,15 +21,16 @@ import SwiftUI
  }
  ```
  */
-@available(iOS 14.0, *) public struct CustomAsyncImage<Output: View>: View {
-    @StateObject var viewModel: ImageViewModel
+public struct CustomAsyncImage<Output: View>: View {
+    @ObservedObject var viewModel: ImageViewModel
     let transform: ((Image) -> Output)?
 
+    /// 
     /// - Parameters:
     ///   - state: the initial state for the async image
     ///   - transform: a closure that will be used to add modifiers to the view
     public init(_ state: ImageViewData, transform: ((Image) -> Output)? = nil) {
-        self._viewModel = StateObject(wrappedValue: ImageViewModel(state: state))
+        self._viewModel = ObservedObject(wrappedValue: ImageViewModel(state: state))
         self.transform = transform
     }
 
@@ -42,7 +43,7 @@ import SwiftUI
                 .onAppear(perform: viewModel.loadImage)
         case .loading:
             placeholder
-                .overlay(ProgressView())
+                .overlay(progressView)
         case let .image(image):
             if let transform = transform {
                 transform(image)
@@ -56,9 +57,20 @@ import SwiftUI
         Rectangle()
             .foregroundColor(.shimmer)
     }
+
+    var progressView: some View {
+        Group {
+            if #available(iOS 14, *) {
+                ProgressView()
+            } else {
+                SimpleRepresentable<RoundLoadingView> { view in
+                    view.startAnimating()
+                }
+            }
+        }
+    }
 }
 
-@available(iOS 14.0, *)
 public extension CustomAsyncImage where Output == Image {
     init(_ state: ImageViewData) {
         self.init(state, transform: nil)

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
@@ -13,3 +13,39 @@ public protocol ImageClient {
     ///                   value if the operation was a success, an error otherwise
     func loadImage(with url: URL, onCompletion: @escaping (Result<Image, Error>) -> Void)
 }
+
+/// Internal only type as a simple/default implementation of the `ImageClient` protocol.
+class DefaultImageClient: ImageClient {
+    var task: URLSessionDataTask?
+
+    func loadImage(with url: URL, onCompletion: @escaping (Result<Image, Error>) -> Void) {
+        task = URLSession.shared.dataTask(with: url) { imageData, _, error in
+            if let imageData = imageData {
+                if let uiImage = UIImage(data: imageData) {
+                    let image = Image(uiImage: uiImage)
+                    onCompletion(.success(image))
+                } else {
+                    onCompletion(.failure(ImageError.decodeError))
+                }
+            } else if let error = error {
+                onCompletion(.failure(error))
+            } else {
+                onCompletion(.failure(ImageError.noData))
+            }
+        }
+
+        task?.resume()
+    }
+
+    enum ImageError: LocalizedError {
+        case decodeError
+        case noData
+
+        var errorDescription: String? {
+            switch self {
+            case .decodeError: return "We got the image data but coudn't convert it to a proper image"
+            case .noData: return "We didn't receive any data, but no error"
+            }
+        }
+    }
+}

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
@@ -43,7 +43,7 @@ class DefaultImageClient: ImageClient {
 
         var errorDescription: String? {
             switch self {
-            case .decodeError: return "We got the image data but coudn't convert it to a proper image"
+            case .decodeError: return "We got the image data but couldn't convert it to a proper image"
             case .noData: return "We didn't receive any data, but no error"
             }
         }

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Requirements for an `ImageClient` to be used in `CustomAsyncImage`.
+///
+/// The main idea is that this UI library is mostly state-less, also the actual
+/// logic of fetching images, which can include caching and more advanced
+/// mechanisms is out of the scope of this library.
+public protocol ImageClient {
+    /// Performs a network request to load the image given the URL
+    /// - Parameters:
+    ///   - url: the URL of the image to load
+    ///   - onCompletion: Closure that will return a result with a `SwiftUI.Image`
+    ///                   value if the operation was a success, an error otherwise
+    func loadImage(with url: URL, onCompletion: @escaping (Result<Image, Error>) -> Void)
+}

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
@@ -16,7 +16,7 @@ import SwiftUI
  */
 public enum ImageViewData: Equatable {
     case empty
-    case remote(url: URL) // what about optionality?
+    case remote(url: URL)
     case loading
     case image(_ image: Image)
 

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/** A generic way to represent Image values.
+
+ When fetching records from a backend, images are usually returned as `URL` types.
+ This means we cannot simply pass that `URL` to the view, because the view
+ end up with logic and state, which is something we want to avoid.
+
+ Then as a solution for this, we can express that "image" concept as
+ `ImageViewData`, this can be rendered with state in a controlled
+ manner by `CustomAsyncImage`, **But we also have the ability to directly pass an image to a view**
+ making it easier to test/develop in isolation.
+
+ The idea is whenever we have a URL that is a representation of an image,
+ we pass `remote(url)` to the view data values.
+ */
+public enum ImageViewData: Equatable {
+    case empty
+    case remote(url: URL) // what about optionality?
+    case loading
+    case image(_ image: Image)
+
+    var url: URL? {
+        guard case let .remote(url) = self else { return nil }
+        return url
+    }
+
+    var image: Image? {
+        guard case let .image(image) = self else { return nil }
+        return image
+    }
+}
+
+extension ImageViewData: Hashable {
+    var hashDescription: String {
+        switch self {
+        case .empty: return "empty"
+        case .image: return "image"
+        case .remote: return "remote"
+        case .loading: return "loading"
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(hashDescription)
+        hasher.combine(url)
+    }
+}

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Implementation detail for `CustomAsyncImage`
+class ImageViewModel: ObservableObject {
+    @Published var state: ImageViewData = .empty
+
+    private var imageClient: ImageClient { Config.imageClient }
+
+    init(state: ImageViewData) {
+        self.state = state
+    }
+
+    func loadImage() {
+        guard case let .remote(imageUrl) = state else { return }
+
+        state = .loading
+        imageClient.loadImage(with: imageUrl) { [weak self] result in
+            switch result {
+            case let .success(image):
+                self?.state = .image(image)
+            case .failure:
+                self?.state = .empty
+            }
+        }
+    }
+}

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
@@ -15,11 +15,13 @@ class ImageViewModel: ObservableObject {
 
         state = .loading
         imageClient.loadImage(with: imageUrl) { [weak self] result in
-            switch result {
-            case let .success(image):
-                self?.state = .image(image)
-            case .failure:
-                self?.state = .empty
+            DispatchQueue.main.async {
+                switch result {
+                case let .success(image):
+                    self?.state = .image(image)
+                case .failure:
+                    self?.state = .empty
+                }
             }
         }
     }

--- a/Sources/SATSCore/Config.swift
+++ b/Sources/SATSCore/Config.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  
+//
+//  Created by Felipe Espinoza on 18/06/2021.
+//
+
+import SwiftUI
+
+public class Config {
+    /// Required initalization for the project.
+    /// This method also allows to customize values like the `ImageClient`
+    /// instance used by `CustomAsyncImage`
+    ///
+    /// - Parameter imageClient: client that performs the load of images is `CustomAsyncImage`
+    public static func setup(imageClient: ImageClient? = nil) {
+        SATSFont.registerCustomFonts()
+
+        _imageClient = imageClient
+    }
+
+    // MARK: Internal properties
+
+    static var imageClient: ImageClient {
+        _imageClient ?? _defaultImageClient
+    }
+
+    // MARK: Private properties
+
+    private static var _imageClient: ImageClient?
+    private static let _defaultImageClient: ImageClient = DefaultImageClient()
+}


### PR DESCRIPTION
After seeing how the `ViewModels` within the main app get complicated by having to fetch all nested structure's images
to be able to create the `ViewData` values I decided to clean up and refine the `CustomAsyncImage`[^1] I showed you before.

This implementation was inspired by the iOS 15 `AsyncImage` component.

You use it like this

```swift
CustomAsyncImage(.remote(url: url)) { image in
     image
         .resizable()
         .aspectRatio(contentMode: .fit)
         .frame(width: 200, height: 200)
         .background(Color.red)
 }
```

The "trick" is that the value for this component is a value of type: `ImageViewData`, which has the following cases

```swift
public enum ImageViewData: Equatable {
    case empty
    case remote(url: URL)
    case loading
    case image(_ image: Image)
}
```

So we can represent URLs as async images through `ImageViewData` and the component will be responsible for actually loading the image.

## Library initalization

Previously we used `SATSFont.registerCustomFonts()` on `AppDelegate` to make sure the library had the fonts it needed to work correctly. Since we need a `ImageClient` instance for the implementation details of `CustomAsyncImage`, I created a new `Config` class that needs to be initialized instead.

```
import SATSCore

// In AppDelegate
Config.setup()
```

This will register the fonts and accept a custom `ImageClient` if we need to.

## ⚠️ Notice

I recommend you to review this per-commit, I added some explanation about the use of `@ObservedObject` instead of `@StateObject` in the relevant commit.


[^1]: If you have a better name for this component, I'm open for that.