### PR TITLE
Fix: `CustomAsyncImage` data retention

### DIFF
--- a/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
@@ -21,6 +21,21 @@ struct CustomAsyncDemoView: View {
                     .background(Color.red)
             }
             .background(Color.blue)
+            /*
+             For demo purposes this is important.
+
+             `CustomAsyncImage` will create an ImageViewModel and that instance
+             will live as long CustomAsyncImage is "alive".
+             Meaning that even the Initializer of the CustomAsyncImage will be
+             called multiple times, the end result will still be the same image,
+             even though the values passed are different.
+
+             This is a good thing when using the component, but, when demo-ing,
+             we want to dispose irrelevant values of `CustomAsyncImage`, which
+             we can achieve by tying the `id` of this view to the `imageViewData`.
+             Then `imageViewData` changes we get a fresh copy of `CustomAsyncImage`
+             */
+            .id(imageViewData)
 
             Spacer()
         }

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -21,16 +21,17 @@ import SwiftUI
  }
  ```
  */
-public struct CustomAsyncImage<Output: View>: View {
-    @ObservedObject var viewModel: ImageViewModel
+@available(iOS 14.0, *) public struct CustomAsyncImage<Output: View>: View {
+    @StateObject var viewModel: ImageViewModel
     let transform: ((Image) -> Output)?
+    let uuid: UUID = UUID()
 
     /// 
     /// - Parameters:
     ///   - state: the initial state for the async image
     ///   - transform: a closure that will be used to add modifiers to the view
     public init(_ state: ImageViewData, transform: ((Image) -> Output)? = nil) {
-        self._viewModel = ObservedObject(wrappedValue: ImageViewModel(state: state))
+        self._viewModel = StateObject(wrappedValue: ImageViewModel(state: state))
         self.transform = transform
     }
 
@@ -43,7 +44,7 @@ public struct CustomAsyncImage<Output: View>: View {
                 .onAppear(perform: viewModel.loadImage)
         case .loading:
             placeholder
-                .overlay(progressView)
+                .overlay(ProgressView())
         case let .image(image):
             if let transform = transform {
                 transform(image)
@@ -57,21 +58,9 @@ public struct CustomAsyncImage<Output: View>: View {
         Rectangle()
             .foregroundColor(.shimmer)
     }
-
-    var progressView: some View {
-        Group {
-            if #available(iOS 14, *) {
-                ProgressView()
-            } else {
-                SimpleRepresentable<RoundLoadingView> { view in
-                    view.startAnimating()
-                }
-                .frame(width: 16, height: 16)
-            }
-        }
-    }
 }
 
+@available(iOS 14.0, *)
 public extension CustomAsyncImage where Output == Image {
     init(_ state: ImageViewData) {
         self.init(state, transform: nil)

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewData.swift
@@ -20,29 +20,29 @@ public enum ImageViewData: Equatable {
     case loading
     case image(_ image: Image)
 
-    var url: URL? {
+    public var url: URL? {
         guard case let .remote(url) = self else { return nil }
         return url
     }
 
-    var image: Image? {
+    public var image: Image? {
         guard case let .image(image) = self else { return nil }
         return image
+    }
+
+    public var description: String {
+        switch self {
+        case .empty: return "empty"
+        case .image: return "image(_)"
+        case let .remote(url): return "remote(url: \(url))"
+        case .loading: return "loading"
+        }
     }
 }
 
 extension ImageViewData: Hashable {
-    var hashDescription: String {
-        switch self {
-        case .empty: return "empty"
-        case .image: return "image"
-        case .remote: return "remote"
-        case .loading: return "loading"
-        }
-    }
-
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(hashDescription)
+        hasher.combine(description)
         hasher.combine(url)
     }
 }


### PR DESCRIPTION
- Fix updating the custom image demo view and write explanation

- Make `CustomAsyncImage` iOS 14+ by using `@StateObject`
  This undoes the choices done in a9f062a7e2940f6dc07890aa0a059db7c8f7a32f

  The main reason for this is that as I'm getting a better understanding of how
  SwiftUI works I realized that the `ImageViewModel` instance lifecycle must be
  tied to the existence of `CustomAsyncImage` so when the image is fetched
  asynchronously we update the view correctly.

  SwiftUI can call the `init` method of views many times, creating multiple
  values for the same view, so the way the initializer worked meant that
  multiple
  `ImageViewModel` instance were gonna be created, even though when that happen
  we didn't duplicate network request, when the request returned
  _we didn't update the image correctly as the old instance of `ImageViewModel`
  was not tied to the new instance of `CustomAsyncImage`_

- Improve underlying data for ImageViewData
  so we now have a description to print if needed.

  Also making public `url` and `image`

