### PR TITLE
Internal: iOS13 conveniences

### DIFF
--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 14.0, *)
 public extension View {
 
     /// Convenience to apply SATSButton styles to SwiftUI buttons
@@ -18,7 +17,7 @@ public extension View {
 /// Internal implementation of `SATSButton` for SwiftUI,
 /// It takes the same parametes as the UIKit implementation
 /// and interprets them in a SwiftUI context
-@available(iOS 14.0, *) private struct SATSButtonSwiftUIStyle: ButtonStyle {
+private struct SATSButtonSwiftUIStyle: ButtonStyle {
     let style: SATSButton.Style
     let size: SATSButton.Size
     let isLoading: Bool
@@ -38,10 +37,16 @@ public extension View {
                 }
                 .frame(width: 20, height: 20, alignment: .center)
             } else {
-                configuration
-                    .label
-                    .satsFont(.button, weight: .medium)
-                    .textCase(.uppercase)
+                if #available(iOS 14.0, *) {
+                    configuration
+                        .label
+                        .satsFont(.button, weight: .medium)
+                        .textCase(.uppercase)
+                } else {
+                    configuration
+                        .label
+                        .satsFont(.button, weight: .medium)
+                }
             }
         }
         .padding(.vertical, size.verticalPadding)

--- a/Sources/SATSCore/Extensions/SwiftUI/View-Utilities.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/View-Utilities.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension View {
+    /// A convenience to the `frame` method to define same width/height dimensions
+    /// - Parameter size: the value for both width and height
+    public func frame(size: CGFloat) -> some View {
+        self.frame(width: size, height: size)
+    }
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/View-iOS13.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/View-iOS13.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension View {
-    /// A easy way to ignore safe area compatible with iOS 13+
+    /// An easy way to ignore safe area compatible with iOS 13+
     @available(iOS, deprecated: 14, message: "Now you should just use `ignoreSafeArea()`")
     public func compatibleIgnoreSafeArea() -> some View {
         Group {

--- a/Sources/SATSCore/Extensions/SwiftUI/View-iOS13.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/View-iOS13.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension View {
+    /// A easy way to ignore safe area compatible with iOS 13+
+    @available(iOS, deprecated: 14, message: "Now you should just use `ignoreSafeArea()`")
+    public func compatibleIgnoreSafeArea() -> some View {
+        Group {
+            if #available(iOS 14.0, *) {
+                self.ignoresSafeArea()
+            } else {
+                self.edgesIgnoringSafeArea(.all)
+            }
+        }
+    }
+}

--- a/Sources/SATSCore/Extensions/UIKit/CGFloat-Utilities.swift
+++ b/Sources/SATSCore/Extensions/UIKit/CGFloat-Utilities.swift
@@ -8,4 +8,8 @@ public extension CGFloat {
     /// Convenience constant for maxWidth in SwiftUI. Replicates UIKit's
     /// readableContent guide's width
     static let readableWidthL: CGFloat = 664
+
+    /// Commonly used value for padding from the horizontal borders
+    /// of the screen
+    static let standardHorizontalPadding: CGFloat = 20
 }


### PR DESCRIPTION
- Make `.satsButton` available for iOS 13
- Add `View.compatibleIgnoreSafeArea` to unify both iOS 13 and 14 APIs to achieve this. Later when we drop iOS 13 we can safely drop this method as this is a transition convenience
- Add `View.frame(size:)` to make frames with same width/height
- Add `.standardHorizontalPadding` to treat the 20pts from the horizontal margin as a constant