### PR TITLE
Improvement: Layout of Swift UI buttons when loading

### DIFF
--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -40,11 +40,6 @@ extension SATSButton.Size: Hashable {
 extension SATSButton.Size {
     var verticalPadding: CGFloat { contentEdgeInsets.top }
     var horizontalPadding: CGFloat { contentEdgeInsets.left }
-
-    // Temporary solution
-    var cornerRadius: CGFloat {
-        self == .large ? 32 : 24
-    }
 }
 
 // MARK: - Default Sizes

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -47,7 +47,7 @@ extension SATSButton.Size {
 public extension SATSButton.Size {
     /// Tall primary button, can grow horizontally.
     static let large = SATSButton.Size(
-        contentEdgeInsets: UIEdgeInsets(all: 20),
+        contentEdgeInsets: UIEdgeInsets(all: 16),
         imageEdgeInsets: .zero,
         contentHuggingPriority: .defaultLow
     )

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -43,7 +43,7 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
         })
         .background(backgroundColor(for: configuration))
         .foregroundColor(textColor(for: configuration))
-        .cornerRadius(size.cornerRadius)
+        .clipShape(Capsule())
     }
 
     // MARK: Subviews

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -30,24 +30,11 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        Group {
-            if isLoading {
-                SimpleRepresentable<RoundLoadingView> { loadingView in
-                    loadingView.startAnimating()
-                }
-                .frame(width: 20, height: 20, alignment: .center)
-            } else {
-                if #available(iOS 14.0, *) {
-                    configuration
-                        .label
-                        .satsFont(.button, weight: .medium)
-                        .textCase(.uppercase)
-                } else {
-                    configuration
-                        .label
-                        .satsFont(.button, weight: .medium)
-                }
-            }
+        ZStack {
+            buttonContent(for: configuration)
+                .opacity(isLoading ? 0.0 : 1.0)
+            spinner
+                .opacity(isLoading ? 1.0 : 0.0)
         }
         .padding(.vertical, size.verticalPadding)
         .padding(.horizontal, size.horizontalPadding)
@@ -57,6 +44,29 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
         .background(backgroundColor(for: configuration))
         .foregroundColor(textColor(for: configuration))
         .cornerRadius(size.cornerRadius)
+    }
+
+    // MARK: Subviews
+
+    @ViewBuilder
+    func buttonContent(for configuration: Configuration) -> some View {
+        if #available(iOS 14.0, *) {
+            configuration
+                .label
+                .satsFont(.button, weight: .medium)
+                .textCase(.uppercase)
+        } else {
+            configuration
+                .label
+                .satsFont(.button, weight: .medium)
+        }
+    }
+
+    var spinner: some View {
+        SimpleRepresentable<RoundLoadingView> { loadingView in
+            loadingView.startAnimating()
+        }
+        .frame(width: 20, height: 20, alignment: .center)
     }
 
     // MARK: Private methods


### PR DESCRIPTION
The buttons would previously change between the loading and text states, now that's solved

Also we have now perfectly rounded buttons with `clipShape(Capsule())` instead of manually setting the corner radius as that was not a solid approach

| Before | After |
|:----:|:----:|
| ![old](https://user-images.githubusercontent.com/167989/125935838-449215f0-483d-4f82-a7c7-607b52189cbd.gif) | ![new](https://user-images.githubusercontent.com/167989/125935853-0ea3935c-7f17-4786-a840-29c5953e9a30.gif) |