### PR TITLE
Improvement: update colors

### DIFF
--- a/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Main/Secondary/secondaryDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF6",
-          "green" : "0xF5",
-          "red" : "0xF3"
+          "blue" : "0xEC",
+          "green" : "0xE9",
+          "red" : "0xE8"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onClean.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onClean.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.200",
-          "green" : "0.129",
-          "red" : "0.055"
+          "blue" : "0x33",
+          "green" : "0x21",
+          "red" : "0x0E"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onCleanDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/On/Clean/onCleanDisabled.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.451",
-          "green" : "0.408",
-          "red" : "0.369"
+          "blue" : "0xAD",
+          "green" : "0xA6",
+          "red" : "0x9F"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/Signal/signalWarning.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Signal/signalWarning.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x00",
-          "green" : "0x6A",
-          "red" : "0x94"
+          "blue" : "0x03",
+          "green" : "0xC9",
+          "red" : "0xFE"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/tabs.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/tabs.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1F",
-          "green" : "0x1F",
-          "red" : "0x1F"
+          "blue" : "0x12",
+          "green" : "0x11",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Background Top/blueGradientEnd.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Background Top/blueGradientEnd.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1A",
-          "green" : "0x1B",
-          "red" : "0x1B"
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Background Top/blueGradientStart.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Background Top/blueGradientStart.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1A",
-          "green" : "0x1B",
-          "red" : "0x1B"
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Some minor updates based on figma.

- Adjust onClean colors
- Update Signal Warning to `#FEC903`
- Update secondary disabled
- Update background Top Start and End colors for Dark Mode
- Adjust `.tabs` color from `#1F1F1F` to `#101112` in Dark Mode