### PR TITLE
Feature: `PullToRefreshContainer` component

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2865CF5A261EDB9A00D6433F /* RoundLoadingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2865CF59261EDB9A00D6433F /* RoundLoadingDemoView.swift */; };
 		9B00E27325B9AE2600533641 /* SATSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9B00E27225B9AE2600533641 /* SATSCore */; };
 		9B00E29725B9D12900533641 /* Demo.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B00E29625B9D12900533641 /* Demo.xcassets */; };
+		9B119AF026E6357C00F05553 /* PullToRefreshContainerDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B119AEF26E6357C00F05553 /* PullToRefreshContainerDemoView.swift */; };
 		9B2BFBDA25B719AD00383193 /* DemoAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBD925B719AD00383193 /* DemoAppApp.swift */; };
 		9B2BFBDC25B719AD00383193 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDB25B719AD00383193 /* ContentView.swift */; };
 		9B2BFBDE25B719AD00383193 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDD25B719AD00383193 /* Assets.xcassets */; };
@@ -57,6 +58,7 @@
 /* Begin PBXFileReference section */
 		2865CF59261EDB9A00D6433F /* RoundLoadingDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoundLoadingDemoView.swift; sourceTree = "<group>"; };
 		9B00E29625B9D12900533641 /* Demo.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Demo.xcassets; sourceTree = "<group>"; };
+		9B119AEF26E6357C00F05553 /* PullToRefreshContainerDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshContainerDemoView.swift; sourceTree = "<group>"; };
 		9B2BFBD625B719AD00383193 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B2BFBD925B719AD00383193 /* DemoAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppApp.swift; sourceTree = "<group>"; };
 		9B2BFBDB25B719AD00383193 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -154,6 +156,14 @@
 				9B2BFBD925B719AD00383193 /* DemoAppApp.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		9B119AEE26E6355C00F05553 /* PullToRefreshContainer */ = {
+			isa = PBXGroup;
+			children = (
+				9B119AEF26E6357C00F05553 /* PullToRefreshContainerDemoView.swift */,
+			);
+			path = PullToRefreshContainer;
 			sourceTree = "<group>";
 		};
 		9B2BFBCD25B719AC00383193 = {
@@ -360,6 +370,7 @@
 				9BCEE85626035CB2001C8692 /* InlineNoticeView */,
 				9BA17B0E26666D2700BDAA9C /* LoadingView */,
 				9BCEE85826035CB2001C8692 /* ProgressLineView */,
+				9B119AEE26E6355C00F05553 /* PullToRefreshContainer */,
 				2865CF58261EDB9A00D6433F /* RoundLoadingView */,
 				9B57208A26738BD600D12109 /* ScoreView */,
 				9BF417162681D25B00E708FD /* ScrollReaderView */,
@@ -538,6 +549,7 @@
 				9BF8D1F92679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift in Sources */,
 				9BA17B1026666D3600BDAA9C /* LoadingDemoView.swift in Sources */,
 				9BFBDEF726DCC93C0066F1C8 /* TabSelectionDemoView.swift in Sources */,
+				9B119AF026E6357C00F05553 /* PullToRefreshContainerDemoView.swift in Sources */,
 				9B9A53A0267CC51500AE9266 /* CustomAsyncImageDemoView.swift in Sources */,
 				9B4083BD261DE66D00A3A718 /* TopBarDemoView.swift in Sources */,
 				9BCEE85B26035CB2001C8692 /* ProgressLineDemoView.swift in Sources */,

--- a/DemoApp/DemoApp/Views/Components/PullToRefreshContainer/PullToRefreshContainerDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/PullToRefreshContainer/PullToRefreshContainerDemoView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PullToRefreshContainerDemoView: View {
-    @State var isLoading: Bool = false
+    @State private var isLoading: Bool = false
 
     var body: some View {
         GeometryReader { proxy in

--- a/DemoApp/DemoApp/Views/Components/PullToRefreshContainer/PullToRefreshContainerDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/PullToRefreshContainer/PullToRefreshContainerDemoView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct PullToRefreshContainerDemoView: View {
+    @State var isLoading: Bool = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            PullToRefreshContainer(isLoading: isLoading, onReload: fauxReload) {
+                Color.blue
+                    .frame(height: proxy.size.height * 1.2)
+            }
+        }
+        .navigationTitle("PullToRefreshContainer")
+    }
+
+    func fauxReload() {
+        isLoading = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation {
+                isLoading = false
+            }
+        }
+    }
+}
+
+struct PullToRefreshContainerDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            PullToRefreshContainerDemoView()
+        }
+    }
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
 
                     Group {
                         NavigationLink("ProgressLineView", destination: ProgressLineDemoView())
+                        NavigationLink("PullToRefreshContainer", destination: PullToRefreshContainerDemoView())
                         NavigationLink("RoundLoadingView", destination: RoundLoadingDemoView())
                         NavigationLink("ScoreView", destination: ScoreDemoView())
                         NavigationLink("ScrollReaderView", destination: ScrollReaderDemoView())

--- a/Sources/SATSCore/Components/PullToRefreshContainer/PullToRefreshContainer.swift
+++ b/Sources/SATSCore/Components/PullToRefreshContainer/PullToRefreshContainer.swift
@@ -16,7 +16,7 @@ import SwiftUI
     message: "This was a backport of the modifier for pull to refresh, now you should use the modifiers on list"
 )
 public struct PullToRefreshContainer<Content: View>: View {
-    @State var scrollValue: CGFloat = 0
+    @State private var scrollValue: CGFloat = 0
     let isLoading: Bool
     let onReload: () -> Void
     var content: Content

--- a/Sources/SATSCore/Components/PullToRefreshContainer/PullToRefreshContainer.swift
+++ b/Sources/SATSCore/Components/PullToRefreshContainer/PullToRefreshContainer.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// A custom pull-to refresh container intended to be used for iOS 14.
+/// The content's height will be set at least to the height of the parent of this container
+///
+/// Example:
+///
+/// ```swift
+/// PullToRefreshContainer(isLoading: value, onReaload: fetchData) {
+///     MyCustomList()
+/// }
+/// ```
+@available(iOS 14.0, *)
+@available(iOS,
+    deprecated: 15,
+    message: "This was a backport of the modifier for pull to refresh, now you should use the modifiers on list"
+)
+public struct PullToRefreshContainer<Content: View>: View {
+    @State var scrollValue: CGFloat = 0
+    let isLoading: Bool
+    let onReload: () -> Void
+    var content: Content
+
+    public init(
+        isLoading: Bool,
+        onReload: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.isLoading = isLoading
+        self.onReload = onReload
+        self.content = content()
+    }
+
+    private let progressHeight: CGFloat = 50
+
+    public var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.clear
+
+                VStack {
+                    ProgressView()
+                        .padding()
+
+                    Spacer()
+                }
+
+                ScrollReaderView(scrollValue: $scrollValue, showsIndicators: false) {
+                    content
+                        .frame(minHeight: proxy.size.height)
+                        .offset(x: 0, y: isLoading ? progressHeight : 0)
+                }
+            }
+        }
+        .clipped()
+        .onChange(of: scrollValue, perform: { value in
+            if value >= progressHeight {
+                onReload()
+            }
+        })
+    }
+}


### PR DESCRIPTION
This is a custom way to implement "pull to refresh" for swiftUI in apps.

This should only be used for iOS 14, as iOS 15 gives support to SwiftUI to
use this natively.

![pull to refresh](https://user-images.githubusercontent.com/167989/132223598-cd0d7556-47a2-40ed-a833-d33eff389455.gif)
