### PR TITLE
Improvement: identifiable list behaviors

### DIFF
--- a/Sources/SATSCore/DataStructures/IdentifiableList.swift
+++ b/Sources/SATSCore/DataStructures/IdentifiableList.swift
@@ -29,6 +29,10 @@ public struct IdentifiableList<Element: Identifiable> {
 
     public var content: [Element] { Array(storage.values) }
 
+    public func contains(_ element: Element) -> Bool {
+        self[element.id] != nil
+    }
+
     // MARK: Mutating functions
 
     public mutating func update(with newValue: Element) {

--- a/Sources/SATSCore/DataStructures/IdentifiableList.swift
+++ b/Sources/SATSCore/DataStructures/IdentifiableList.swift
@@ -35,7 +35,9 @@ public struct IdentifiableList<Element: Identifiable> {
 
     // MARK: Mutating functions
 
+    /// Updates an existing value from the collection
     public mutating func update(with newValue: Element) {
+        guard contains(newValue) else { return }
         self[newValue.id] = newValue
     }
 


### PR DESCRIPTION
- Ensure we only `update` an element if it's present in `IdentifiableList`
- Add `IdentifiableList#contains` method
  To as a set, figure out if an element is included in the list or not (by id)
