### PR TITLE
Feature: view data for alerts and action sheets

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/ActionSheetViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/ActionSheetViewData.swift
@@ -6,9 +6,21 @@ public struct ActionSheetViewData: Identifiable, Equatable {
     public let message: String?
     public let actions: [ActionViewData]
 
+    public init(id: String? = nil, title: String, message: String?, actions: [ActionViewData]) {
+        self.id = id ?? UUID().uuidString
+        self.title = title
+        self.message = message
+        self.actions = actions
+    }
+
     public struct ActionViewData: Equatable {
         public let title: String
         public let perform: () -> Void
+
+        public init(title: String, perform: @escaping () -> Void) {
+            self.title = title
+            self.perform = perform
+        }
 
         public static func == (lhs: Self, rhs: Self) -> Bool {
             lhs.title == rhs.title

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/ActionSheetViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/ActionSheetViewData.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+public struct ActionSheetViewData: Identifiable, Equatable {
+    public let id: String
+    public let title: String
+    public let message: String?
+    public let actions: [ActionViewData]
+
+    public struct ActionViewData: Equatable {
+        public let title: String
+        public let perform: () -> Void
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.title == rhs.title
+        }
+    }
+}
+
+public extension ActionSheet {
+    init(viewData: ActionSheetViewData) {
+        var buttons: [Button] = viewData.actions
+            .map { action in
+                Button.default(Text(action.title), action: action.perform)
+            }
+        buttons.append(.cancel())
+
+        self.init(
+            title: Text(viewData.title),
+            message: viewData.message.map { Text($0) },
+            buttons: buttons
+        )
+    }
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
@@ -10,6 +10,20 @@ public struct AlertViewData: Identifiable, Equatable {
     public let actionTitle: String
     public let action: () -> Void
 
+    public init(
+        id: String? = nil,
+        title: String,
+        message: String,
+        actionTitle: String,
+        action: @escaping () -> Void
+    ) {
+        self.id = id ?? UUID().uuidString
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
     public static func == (lhs: AlertViewData, rhs: AlertViewData) -> Bool {
         lhs.id == rhs.id &&
             lhs.title == rhs.title &&

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// A way to represent the content of an alert, that is testable
+/// due that we cannot inspect the properties of a `SwiftUI.Alert`
+/// value
+public struct AlertViewData: Identifiable, Equatable {
+    public let id: String
+    public let title: String
+    public let message: String
+    public let actionTitle: String
+    public let action: () -> Void
+
+    public static func == (lhs: AlertViewData, rhs: AlertViewData) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.message == rhs.message &&
+            lhs.actionTitle == rhs.actionTitle
+    }
+}
+
+public extension Alert {
+    /// Creates an alert from view data, this include a default cancel button
+    init(viewData: AlertViewData) {
+        self.init(
+            title: Text(viewData.title),
+            message: Text(viewData.message),
+            primaryButton: .default(Text(viewData.actionTitle), action: viewData.action),
+            secondaryButton: .cancel()
+        )
+    }
+}


### PR DESCRIPTION
`Alert` and `ActionSheet` in SwiftUI are structs, but from the view model perspective it's not easy to work with them

once we create an `Alert` value, we cannot inspect its properties. It's title and so on.

Then following the patterns of `ViewData` I created `AlertViewData` and `ActionSheetViewData` to work with them.

I also added some convenience initializers for `Alert` and `ActionSheet` that take their view data variants.