### PR TITLE
Feature: inline notice

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		9B4083BE261DE66D00A3A718 /* ExternalUrlDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4083BA261DE66D00A3A718 /* ExternalUrlDemoView.swift */; };
 		9B4083BF261DE66D00A3A718 /* ArticlePageViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4083BC261DE66D00A3A718 /* ArticlePageViewDemo.swift */; };
 		9B57208C26738BF100D12109 /* ScoreDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B57208B26738BF100D12109 /* ScoreDemoView.swift */; };
+		9B6BC4F726E8F38700650862 /* NoticeDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6BC4F126E8F38700650862 /* NoticeDemoView.swift */; };
 		9B75EC45264B1D5300B160EF /* EmptyStateDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B75EC44264B1D5300B160EF /* EmptyStateDemoView.swift */; };
 		9B78777925D68D9A00C69BB8 /* FontWeightPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78777825D68D9A00C69BB8 /* FontWeightPicker.swift */; };
 		9B7A4D5025D2ADA30086EA4F /* DemoDiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7A4D4B25D2ADA30086EA4F /* DemoDiscoverView.swift */; };
@@ -71,6 +72,7 @@
 		9B4083BA261DE66D00A3A718 /* ExternalUrlDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExternalUrlDemoView.swift; sourceTree = "<group>"; };
 		9B4083BC261DE66D00A3A718 /* ArticlePageViewDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticlePageViewDemo.swift; sourceTree = "<group>"; };
 		9B57208B26738BF100D12109 /* ScoreDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreDemoView.swift; sourceTree = "<group>"; };
+		9B6BC4F126E8F38700650862 /* NoticeDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoticeDemoView.swift; sourceTree = "<group>"; };
 		9B75EC44264B1D5300B160EF /* EmptyStateDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateDemoView.swift; sourceTree = "<group>"; };
 		9B78777825D68D9A00C69BB8 /* FontWeightPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontWeightPicker.swift; sourceTree = "<group>"; };
 		9B7A4D4B25D2ADA30086EA4F /* DemoDiscoverView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoDiscoverView.swift; sourceTree = "<group>"; };
@@ -308,6 +310,14 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		9B8C11F226F23702007F5D0C /* NoticeView */ = {
+			isa = PBXGroup;
+			children = (
+				9B6BC4F126E8F38700650862 /* NoticeDemoView.swift */,
+			);
+			path = NoticeView;
+			sourceTree = "<group>";
+		};
 		9B96339726DCD36800656D61 /* DemoAppTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -369,6 +379,7 @@
 				9B9D6D91261EF6E300450E67 /* GradientView */,
 				9BCEE85626035CB2001C8692 /* InlineNoticeView */,
 				9BA17B0E26666D2700BDAA9C /* LoadingView */,
+				9B8C11F226F23702007F5D0C /* NoticeView */,
 				9BCEE85826035CB2001C8692 /* ProgressLineView */,
 				9B119AEE26E6355C00F05553 /* PullToRefreshContainer */,
 				2865CF58261EDB9A00D6433F /* RoundLoadingView */,
@@ -547,6 +558,7 @@
 				9B7A4D5225D2ADA30086EA4F /* SampleTopStoriesView.swift in Sources */,
 				9B4083BE261DE66D00A3A718 /* ExternalUrlDemoView.swift in Sources */,
 				9BF8D1F92679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift in Sources */,
+				9B6BC4F726E8F38700650862 /* NoticeDemoView.swift in Sources */,
 				9BA17B1026666D3600BDAA9C /* LoadingDemoView.swift in Sources */,
 				9BFBDEF726DCC93C0066F1C8 /* TabSelectionDemoView.swift in Sources */,
 				9B119AF026E6357C00F05553 /* PullToRefreshContainerDemoView.swift in Sources */,

--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -10,16 +10,12 @@ import SwiftUI
 struct NoticeDemoView: View {
     @State var notice: Notice?
 
-    @State var includeIcon: Bool = false
     @State var includeSubtitle: Bool = false
     @State var autoDismiss: Bool = true
     @State var edgeTop: Bool = true
     @State var style: Style = .success
 
     var edge: Notice.Edge { edgeTop ? .top : .bottom }
-    var icon: Image? {
-        includeIcon ? Image(systemName: style.iconName) : nil
-    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -42,7 +38,6 @@ struct NoticeDemoView: View {
 
     @ViewBuilder var noticeEditor: some View {
         VStack {
-            Toggle("Include Icon?", isOn: $includeIcon)
             Toggle("Include Subtitle?", isOn: $includeSubtitle)
             Toggle("Auto dismiss?", isOn: $autoDismiss)
             Toggle("Top Edge?", isOn: $edgeTop)
@@ -86,21 +81,18 @@ struct NoticeDemoView: View {
         switch style {
         case .success:
             return Notice.success(
-                icon: icon,
                 title: "Sample success notice",
                 explanation: includeSubtitle ? "Subtitle text" : nil,
                 autoDismiss: autoDismiss
             )
         case .warning:
             return Notice.warning(
-                icon: icon,
                 title: "Sample warning notice",
                 explanation: includeSubtitle ? "Subtitle text" : nil,
                 autoDismiss: autoDismiss
             )
         case .error:
             return Notice.error(
-                icon: icon,
                 title: "Sample error notice",
                 explanation: includeSubtitle ? "Subtitle text" : nil,
                 autoDismiss: autoDismiss
@@ -115,14 +107,6 @@ struct NoticeDemoView: View {
         case success = "Success"
         case warning = "Warning"
         case error = "Error"
-
-        var iconName: String {
-            switch self {
-            case .success: return "checkmark.circle.fill"
-            case .warning: return "exclamationmark.triangle.fill"
-            case .error: return "xmark.octagon.fill"
-            }
-        }
     }
 }
 
@@ -147,7 +131,6 @@ struct ErrorNoticeView_Previews: PreviewProvider {
 
 extension Notice {
     static let sampleError = Notice.error(
-        icon: Image(systemName: "xmark.octagon.fill"),
         title: "This is a sample error"
     )
 

--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -57,7 +57,6 @@ struct NoticeDemoView: View {
                     Text("Warning").tag(Style.warning)
                     Text("Error").tag(Style.error)
                 }
-                .font(.body.bold())
                 .pickerStyle(MenuPickerStyle())
                 .padding(4)
             }

--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -1,0 +1,163 @@
+//
+//  ErrorNoticeView.swift
+//  DemoApp
+//
+//  Created by Felipe Espinoza on 24/06/2021.
+//
+
+import SwiftUI
+
+struct NoticeDemoView: View {
+    @State var notice: Notice?
+
+    @State var includeIcon: Bool = false
+    @State var includeSubtitle: Bool = false
+    @State var autoDismiss: Bool = true
+    @State var edgeTop: Bool = true
+    @State var style: Style = .success
+
+    var edge: Notice.Edge { edgeTop ? .top : .bottom }
+    var icon: Image? {
+        includeIcon ? Image(systemName: style.iconName) : nil
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            VStack(spacing: 30) {
+                Spacer()
+
+                Button("Toggle Notice", action: toggleNotice)
+                    .satsButton(.primary, size: .large)
+
+                Spacer()
+            }
+            .padding()
+
+            noticeEditor
+        }
+        .inlineNotice($notice, edge: edge)
+        .background(Color.backgroundPrimary)
+        .navigationTitle("Notice")
+    }
+
+    @ViewBuilder var noticeEditor: some View {
+        VStack {
+            Toggle("Include Icon?", isOn: $includeIcon)
+            Toggle("Include Subtitle?", isOn: $includeSubtitle)
+            Toggle("Auto dismiss?", isOn: $autoDismiss)
+            Toggle("Top Edge?", isOn: $edgeTop)
+
+            HStack {
+                Text("Style")
+
+                Spacer()
+
+                Picker("\(style.rawValue)", selection: $style) {
+                    Text("Success").tag(Style.success)
+                    Text("Warning").tag(Style.warning)
+                    Text("Error").tag(Style.error)
+                }
+                .font(.body.bold())
+                .pickerStyle(MenuPickerStyle())
+                .padding(4)
+            }
+        }
+        .padding()
+        .accentColor(Color.primary)
+        .background(Color.backgroundSurface)
+    }
+
+    func toggleNotice() {
+        if notice != nil {
+            // when manually dismissing the notice
+            // it's better to wrap that code with an
+            // `withAnimation` block
+            withAnimation {
+                notice = nil
+            }
+        } else {
+            notice = createNotice()
+        }
+    }
+
+    // This is the normal way to create `Notice` values
+    // by using the `.success`, `.warning` and `.error`
+    // factory methods which contain sensible defaults
+    private func createNotice() -> Notice {
+        switch style {
+        case .success:
+            return Notice.success(
+                icon: icon,
+                title: "Sample success notice",
+                explanation: includeSubtitle ? "Subtitle text" : nil,
+                autoDismiss: autoDismiss
+            )
+        case .warning:
+            return Notice.warning(
+                icon: icon,
+                title: "Sample warning notice",
+                explanation: includeSubtitle ? "Subtitle text" : nil,
+                autoDismiss: autoDismiss
+            )
+        case .error:
+            return Notice.error(
+                icon: icon,
+                title: "Sample error notice",
+                explanation: includeSubtitle ? "Subtitle text" : nil,
+                autoDismiss: autoDismiss
+            )
+        }
+    }
+
+    // This `style` enum is only for the demo
+    // In general I favor struct values over enums as they are
+    // extensible outside the library
+    enum Style: String, Hashable {
+        case success = "Success"
+        case warning = "Warning"
+        case error = "Error"
+
+        var iconName: String {
+            switch self {
+            case .success: return "checkmark.circle.fill"
+            case .warning: return "exclamationmark.triangle.fill"
+            case .error: return "xmark.octagon.fill"
+            }
+        }
+    }
+}
+
+struct ErrorNoticeView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            NoticeDemoView()
+                .background(Color.red)
+                .previewDevice("iPhone 12 Pro")
+
+            Group {
+                NoticeView(notice: .sampleSuccess)
+
+                NoticeView(notice: .sampleWarning)
+
+                NoticeView(notice: .sampleError)
+            }
+            .previewLayout(.sizeThatFits)
+        }
+    }
+}
+
+extension Notice {
+    static let sampleError = Notice.error(
+        icon: Image(systemName: "xmark.octagon.fill"),
+        title: "This is a sample error"
+    )
+
+    static let sampleSuccess = Notice.success(
+        title: "Your operation was succesful",
+        explanation: "everything is awesome!"
+    )
+
+    static let sampleWarning = Notice.warning(
+        title: "You should be careful about this!"
+    )
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
                     NavigationLink("GradientView", destination: GradientDemoView())
                     NavigationLink("InlineNoticeView", destination: InlineNoticeDemoView())
                     NavigationLink("LoadingView", destination: LoadingDemoView())
+                    NavigationLink("NoticeView", destination: NoticeDemoView())
 
                     Group {
                         NavigationLink("ProgressLineView", destination: ProgressLineDemoView())

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -33,21 +33,19 @@ public struct Notice {
 
     /// Creates an error notice data struct
     /// - Parameters:
-    ///   - icon: (optional) icon
     ///   - title: required title of the error
     ///   - explanation: (optional) explanation of the error
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func error(
-        icon: Image? = nil,
         title: String,
         explanation: String? = nil,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: icon,
+            icon: Image(systemName: "xmark.octagon.fill"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
@@ -59,21 +57,19 @@ public struct Notice {
 
     /// Creates a warning notice data struct
     /// - Parameters:
-    ///   - icon: (optional) icon
     ///   - title: required title of the warning
     ///   - explanation: (optional) explanation of the warning
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView
     public static func warning(
-        icon: Image? = nil,
         title: String,
         explanation: String? = nil,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: icon,
+            icon: Image(systemName: "exclamationmark.triangle.fill"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
@@ -85,21 +81,19 @@ public struct Notice {
 
     /// Creates a success notice data struct
     /// - Parameters:
-    ///   - icon: (optional) icon
     ///   - title: required title of the notice
     ///   - explanation: (optional) explanation of the notice
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView
     public static func success(
-        icon: Image? = nil,
         title: String,
         explanation: String? = nil,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: icon,
+            icon: Image(systemName: "checkmark.circle.fill"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Notice is a generic way to configure the `NoticeView` component
+/// This struct is available on its own to define custom styles if needed.
+/// Normally using `Notice.error`, `Notice.warning` or `Notice.success`
+/// is enough
+public struct Notice {
+    public let icon: Image?
+    public let title: String
+    public let explanation: String?
+    public let autoDismiss: Bool
+    public let foregroundColor: Color
+    public let backgroundColor: Color
+    public let hapticType: UINotificationFeedbackGenerator.FeedbackType?
+
+    public init(
+        icon: Image? = nil,
+        title: String,
+        explanation: String? = nil,
+        autoDismiss: Bool = true,
+        foregroundColor: Color,
+        backgroundColor: Color,
+        hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil
+    ) {
+        self.icon = icon
+        self.title = title
+        self.explanation = explanation
+        self.autoDismiss = autoDismiss
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+        self.hapticType = hapticType
+    }
+
+    /// Creates an error notice data struct
+    /// - Parameters:
+    ///   - icon: (optional) icon
+    ///   - title: required title of the error
+    ///   - explanation: (optional) explanation of the error
+    ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
+    ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
+    /// - Returns: a `Notice` instance that can be used with `NoticeView`
+    public static func error(
+        icon: Image? = nil,
+        title: String,
+        explanation: String? = nil,
+        autoDismiss: Bool = true,
+        includeHaptic: Bool = true
+    ) -> Notice {
+        Notice(
+            icon: icon,
+            title: title,
+            explanation: explanation,
+            autoDismiss: autoDismiss,
+            foregroundColor: .onSignal,
+            backgroundColor: .signalError,
+            hapticType: includeHaptic ? .error : nil
+        )
+    }
+
+    /// Creates a warning notice data struct
+    /// - Parameters:
+    ///   - icon: (optional) icon
+    ///   - title: required title of the warning
+    ///   - explanation: (optional) explanation of the warning
+    ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
+    ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
+    /// - Returns: a `Notice` instance that can be used with `NoticeView
+    public static func warning(
+        icon: Image? = nil,
+        title: String,
+        explanation: String? = nil,
+        autoDismiss: Bool = true,
+        includeHaptic: Bool = true
+    ) -> Notice {
+        Notice(
+            icon: icon,
+            title: title,
+            explanation: explanation,
+            autoDismiss: autoDismiss,
+            foregroundColor: .onSignal,
+            backgroundColor: .signalWarning,
+            hapticType: includeHaptic ? .warning : nil
+        )
+    }
+
+    /// Creates a success notice data struct
+    /// - Parameters:
+    ///   - icon: (optional) icon
+    ///   - title: required title of the notice
+    ///   - explanation: (optional) explanation of the notice
+    ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
+    ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
+    /// - Returns: a `Notice` instance that can be used with `NoticeView
+    public static func success(
+        icon: Image? = nil,
+        title: String,
+        explanation: String? = nil,
+        autoDismiss: Bool = true,
+        includeHaptic: Bool = true
+    ) -> Notice {
+        Notice(
+            icon: icon,
+            title: title,
+            explanation: explanation,
+            autoDismiss: autoDismiss,
+            foregroundColor: .onSignal,
+            backgroundColor: .signalSuccess,
+            hapticType: includeHaptic ? .success : nil
+        )
+    }
+}
+
+public extension Notice {
+    enum Edge: String, Identifiable, Hashable, Equatable {
+        case top
+        case bottom
+
+        public var id: String { rawValue }
+    }
+}

--- a/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Internal modifier, it should only be used via the `View.inlineNotice` method
+struct NoticeModifier: ViewModifier {
+    @Binding var notice: Notice?
+    let edge: Notice.Edge
+
+    private let transitionDuration: TimeInterval = 0.2
+    private let autoDismissTime: TimeInterval = 3
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            noticeOverlay
+        }
+        .clipped()
+    }
+
+    var noticeOverlay: some View {
+        VStack {
+            topSpacer
+            noticeView
+            bottomSpacer
+        }
+    }
+
+    @ViewBuilder var noticeView: some View {
+        if let notice = notice {
+            NoticeView(notice: notice, onTap: dimissNotice)
+                .animation(.easeInOut(duration: transitionDuration))
+                .transition(.move(edge: edge == .top ? .top : .bottom))
+                .onAppear(perform: scheduleAutoDismissIfNeeded)
+                .onAppear(perform: semanticHapticIfNeeded)
+        }
+    }
+
+    @ViewBuilder private var topSpacer: some View {
+        if edge == .bottom {
+            Spacer()
+        }
+    }
+
+    @ViewBuilder private var bottomSpacer: some View {
+        if edge == .top {
+            Spacer()
+        }
+    }
+
+    private func dimissNotice() {
+        withAnimation { notice = nil }
+    }
+
+    private func scheduleAutoDismissIfNeeded() {
+        guard
+            let notice = notice,
+            notice.autoDismiss
+        else { return }
+
+        DispatchQueue
+            .main
+            .asyncAfter(
+                deadline: .now() + autoDismissTime,
+                execute: dimissNotice
+            )
+    }
+
+    private func semanticHapticIfNeeded() {
+        guard let hapticType = notice?.hapticType else { return }
+
+        UINotificationFeedbackGenerator().notificationOccurred(hapticType)
+    }
+}
+
+public extension View {
+    /// Adds a inline notice to the screen
+    /// - Parameters:
+    ///   - notice: inline notice content to show
+    ///   - edge: which edge to default `.top` (options: `.top` and `.bottom`)
+    /// - Returns: applies the internal modifier that wraps a view in a zstack and manages the behavior of the notice
+    func inlineNotice(_ notice: Binding<Notice?>, edge: Notice.Edge = .top) -> some View {
+        self.modifier(NoticeModifier(notice: notice, edge: edge))
+    }
+}

--- a/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
@@ -6,7 +6,7 @@ struct NoticeModifier: ViewModifier {
     let edge: Notice.Edge
 
     private let transitionDuration: TimeInterval = 0.2
-    private let autoDismissTime: TimeInterval = 3
+    private let autoDismissTime: TimeInterval = 5
 
     func body(content: Content) -> some View {
         ZStack {

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+public struct NoticeView: View {
+    let notice: Notice
+    let onTap: (() -> Void)?
+
+    public init(notice: Notice, onTap: (() -> Void)? = nil) {
+        self.notice = notice
+        self.onTap = onTap
+    }
+
+    public var body: some View {
+        HStack {
+            icon
+            message
+            Spacer()
+        }
+        .foregroundColor(notice.foregroundColor)
+        .padding()
+        .background(notice.backgroundColor)
+        .cornerRadius(8)
+        .padding(8)
+        .onTapGesture(perform: performTap)
+        .frame(maxWidth: .readableWidthM)
+    }
+
+    func performTap() {
+        onTap?()
+    }
+
+    @ViewBuilder var icon: some View {
+        if let icon = notice.icon {
+            icon
+        }
+    }
+
+    var message: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(notice.title)
+                .satsFont(.basic, weight: .emphasis)
+
+            if let explanation = notice.explanation {
+                Text(explanation)
+                    .satsFont(.small)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds

```
View.inlineNotice(_ notice: Binding<Notice?>, edge: Notice.Edge = .top)
```

To add a message overlay when needed, good for inline errors.

![Simulator Screen Recording - iPhone 12 Pro - 2021-09-15 at 16 17 06](https://user-images.githubusercontent.com/167989/133450649-caeb30dd-9059-4921-9c92-e6f7696d6a95.gif)

The way you create the `Notice` object looks like:

```swift
Notice.success(title: "This went ok!")

Notice.warning(title: "Are you sure about this?")

Notice.error(title: "These are not the droids you are looking for")
```

⚠️ When reviewing, take a look at the options when creating a notice.

⚠️ Also I feel the `Notice` concept, `.inlineNotice` is somewhat inconsistent across the implementation so feel free to suggest (with examples of usage), better names for these parts of the feature.

⚠️ There is one behavior that is not solved and it's just a issue in the demo: when manually dismissing a notice and showing a new one just after, it may auto dismiss immediately as I don't distinguish between new and old notices when using `DispatchQueue.main.async` to auto-dismiss the notice. I'm open for suggestions here too