### PR TITLE
Improvement: support for Dynamic Type for iOS 14+

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:healthfitnessnordic/SATSType-iOS.git",
         "state": {
           "branch": null,
-          "revision": "0a8f4d295169febbce9b99485589b03314b4bb15",
-          "version": "0.0.1"
+          "revision": "7226330dc2c014d49e9b126fc67e8ddc0b0b62e9",
+          "version": "0.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(
             name: "SATSType",
             url: "git@github.com:healthfitnessnordic/SATSType-iOS.git",
-            .upToNextMajor(from: "0.0.1")
+            .upToNextMajor(from: "0.0.2")
         ),
     ],
     targets: [

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -1,8 +1,19 @@
 import SwiftUI
 
 public extension View {
-    @inlinable func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> some View {
-        self.font(Font(SATSFont.font(style: style, weight: weight)))
+    @ViewBuilder @inlinable
+    func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> some View {
+        if #available(iOS 14.0, *) {
+            self.font(
+                .custom(
+                    SATSFont.fontName(for: weight),
+                    size: style.size,
+                    relativeTo: SATSFont.style(for: style.nativeStyle)
+                )
+            )
+        } else {
+            self.font(Font(SATSFont.font(style: style, weight: weight)))
+        }
     }
 }
 

--- a/Sources/SATSCore/DNA/Font/SATSFont.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SATSType
+import SwiftUI
 
 public struct SATSFont {
     public static func registerCustomFonts() {
@@ -8,5 +9,34 @@ public struct SATSFont {
 
     public static func font(style: TextStyle, weight: Weight) -> UIFont {
         FontAccess.font(textStyle: style.nativeStyle, size: style.size, variantName: weight.fontName)
+    }
+
+    public static func fontName(for weight: Weight) -> String {
+        FontAccess.fontName(for: weight.fontName)
+    }
+
+    /// Converts the UIKit text style into SwiftUI text style
+    public static func style(for textStyle: UIFont.TextStyle) -> Font.TextStyle {
+        switch textStyle {
+        case .title1: return .title
+        case .title2:
+            if #available(iOS 14.0, *) {
+                return .title2
+            } else {
+                return .title
+            }
+        case .title3:
+            if #available(iOS 14.0, *) {
+                return .title3
+            } else {
+                return .title
+            }
+        case .body: return .body
+        case .callout: return .callout
+        case .footnote: return .footnote
+        case .subheadline: return .subheadline
+        default:
+            fatalError("❌ unhandled UIKit to SwiftUI text style conversion")
+        }
     }
 }


### PR DESCRIPTION
This depends on https://github.com/healthfitnessnordic/SATSType-iOS/pull/1

The way to support custom fonts with dynamic type changed in iOS 14
https://www.hackingwithswift.com/quick-start/swiftui/how-to-use-dynamic-type-with-a-custom-font

I could have added support for iOS 13 as well, but I opted not to, as
the idea is to drop iOS 13 soon.