### PR TITLE
Fix: unwanted content clipping for `.inlineNotice`

### DIFF
--- a/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
@@ -9,11 +9,14 @@ struct NoticeModifier: ViewModifier {
     private let autoDismissTime: TimeInterval = 5
 
     func body(content: Content) -> some View {
-        ZStack {
-            content
-            noticeOverlay
-        }
-        .clipped()
+        content
+            .overlay(
+                ZStack {
+                    Color.clear
+                    noticeOverlay
+                }
+                .clipped()
+            )
     }
 
     var noticeOverlay: some View {


### PR DESCRIPTION
We had some issues with the `.inlineNotice` modifier within the app due
to the `.clipped` modifier usage.

The main issue is that we were clipping the content itself in an attempt
to clip the overlay that animates in/out the notice view.

Then I reordered the modifiers to only apply `clipped` to the
`noticeOverlay` rather than the original content.

I tested this change in the iOS app and this fixes the issues we saw.
