### PR TITLE
Fix: changing the button style updates the spinner

### DIFF
--- a/DemoApp/DemoApp/Views/Components/TopBarView/TopBarDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/TopBarView/TopBarDemoView.swift
@@ -39,7 +39,7 @@ struct TopBarDemoView_Previews: PreviewProvider {
             NavigationView {
                 TopBarDemoView()
             }
- 
+
             NavigationView {
                 TopBarDemoView()
             }.preferredColorScheme(.dark)

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -35,6 +35,7 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
                 .opacity(isLoading ? 0.0 : 1.0)
             spinner
                 .opacity(isLoading ? 1.0 : 0.0)
+                .id(style.name)
         }
         .padding(.vertical, size.verticalPadding)
         .padding(.horizontal, size.horizontalPadding)

--- a/azure-devops/azure-pipelines-test.yml
+++ b/azure-devops/azure-pipelines-test.yml
@@ -33,7 +33,7 @@ jobs:
         displayName: "Workaround for private SSH SPM dependencies"
         inputs:
           targetType: "inline"
-          script: "for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts"
+          script: "for ip in $(dig @8.8.8.8 gitlab.com +short); do ssh-keyscan -t ecdsa github.com,$ip; done 2>/dev/null >> ~/.ssh/known_hosts"
           failOnStderr: true
 
       - task: Xcode@5


### PR DESCRIPTION
I notice if we change a given button from a primary to a secondary style,
the loading indicator is not visible, this is because:

1. if the button was in `.secondary` style
2. we show the indicator (with a blue color on top)
3. we change the button to `.primary` style
4. we set the button to `loading`, but we don't see the indicator.

The indicator is still present, but not visible as the indicator style doesn't get
refreshed when changing the button's style.

Then the solution is to use the `style.name` as `id` to make the spinner refresh
when the style is changed.