### PR TITLE
Improvement: allow to "retry" on error notices

### DIFF
--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -13,6 +13,7 @@ struct NoticeDemoView: View {
     @State var includeSubtitle: Bool = false
     @State var autoDismiss: Bool = true
     @State var edgeTop: Bool = true
+    @State var withRetry: Bool = false
     @State var style: Style = .success
 
     var edge: Notice.Edge { edgeTop ? .top : .bottom }
@@ -41,6 +42,9 @@ struct NoticeDemoView: View {
             Toggle("Include Subtitle?", isOn: $includeSubtitle)
             Toggle("Auto dismiss?", isOn: $autoDismiss)
             Toggle("Top Edge?", isOn: $edgeTop)
+            if style == .error {
+                Toggle("With Retry?", isOn: $withRetry)
+            }
 
             HStack {
                 Text("Style")
@@ -78,23 +82,35 @@ struct NoticeDemoView: View {
     // by using the `.success`, `.warning` and `.error`
     // factory methods which contain sensible defaults
     private func createNotice() -> Notice {
-        switch style {
-        case .success:
+        let subtitle = includeSubtitle ? "Subtitle text" : nil
+
+        switch (style, withRetry) {
+        case (.success, _):
             return Notice.success(
                 title: "Sample success notice",
-                explanation: includeSubtitle ? "Subtitle text" : nil,
+                explanation: subtitle,
                 autoDismiss: autoDismiss
             )
-        case .warning:
+
+        case (.warning, _):
             return Notice.warning(
                 title: "Sample warning notice",
-                explanation: includeSubtitle ? "Subtitle text" : nil,
+                explanation: subtitle,
                 autoDismiss: autoDismiss
             )
-        case .error:
+
+        case (.error, true):
             return Notice.error(
                 title: "Sample error notice",
-                explanation: includeSubtitle ? "Subtitle text" : nil,
+                explanation: subtitle,
+                retryTitle: "Retry",
+                onRetry: { print("on retry!") }
+            )
+
+        case (.error, false):
+            return Notice.error(
+                title: "Sample error notice",
+                explanation: subtitle,
                 autoDismiss: autoDismiss
             )
         }
@@ -123,6 +139,8 @@ struct ErrorNoticeView_Previews: PreviewProvider {
                 NoticeView(notice: .sampleWarning)
 
                 NoticeView(notice: .sampleError)
+
+                NoticeView(notice: .sampleErrorWithRetry)
             }
             .previewLayout(.sizeThatFits)
         }
@@ -132,6 +150,12 @@ struct ErrorNoticeView_Previews: PreviewProvider {
 extension Notice {
     static let sampleError = Notice.error(
         title: "This is a sample error"
+    )
+
+    static let sampleErrorWithRetry = Notice.error(
+        title: "This is a sample error",
+        retryTitle: "Retry",
+        onRetry: { print("Sample") }
     )
 
     static let sampleSuccess = Notice.success(

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -61,6 +61,35 @@ public struct Notice {
         )
     }
 
+    /// Create a error notice with retry options
+    /// - Parameters:
+    ///   - title: required title of the error
+    ///   - explanation: (optional) explanation of the error
+    ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
+    ///   - retryTitle: title for the retry button
+    ///   - onRetry: callback when the try button is tapped
+    /// - Returns: returns a error `Notice` that won't autodismiss that allows to retry
+    ///            an operation that caused an error
+    public static func error(
+        title: String,
+        explanation: String? = nil,
+        includeHaptic: Bool = true,
+        retryTitle: String,
+        onRetry: @escaping () -> Void
+    ) -> Notice {
+        Notice(
+            icon: Image(systemName: "xmark.octagon.fill"),
+            title: title,
+            explanation: explanation,
+            autoDismiss: false,
+            foregroundColor: .onSignal,
+            backgroundColor: .signalError,
+            hapticType: includeHaptic ? .error : nil,
+            retryTitle: retryTitle,
+            onRetry: onRetry
+        )
+    }
+
     /// Creates a warning notice data struct
     /// - Parameters:
     ///   - title: required title of the warning

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -12,6 +12,8 @@ public struct Notice {
     public let foregroundColor: Color
     public let backgroundColor: Color
     public let hapticType: UINotificationFeedbackGenerator.FeedbackType?
+    public let retryTitle: String?
+    public let onRetry: (() -> Void)?
 
     public init(
         icon: Image? = nil,
@@ -20,7 +22,9 @@ public struct Notice {
         autoDismiss: Bool = true,
         foregroundColor: Color,
         backgroundColor: Color,
-        hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil
+        hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil,
+        retryTitle: String? = nil,
+        onRetry: (() -> Void)? = nil
     ) {
         self.icon = icon
         self.title = title
@@ -29,6 +33,8 @@ public struct Notice {
         self.foregroundColor = foregroundColor
         self.backgroundColor = backgroundColor
         self.hapticType = hapticType
+        self.retryTitle = retryTitle
+        self.onRetry = onRetry
     }
 
     /// Creates an error notice data struct

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -36,7 +36,7 @@ public struct NoticeView: View {
                     .frame(height: 16)
 
                 Button(action: onRetry) {
-                    Text(retryTitle)
+                    Text(retryTitle.uppercased())
                         .satsFont(.basic, weight: .emphasis)
                 }
                 .padding(.horizontal, 8)

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -14,6 +14,7 @@ public struct NoticeView: View {
             icon
             message
             Spacer()
+            retryButton
         }
         .foregroundColor(notice.foregroundColor)
         .padding(16)
@@ -26,6 +27,18 @@ public struct NoticeView: View {
 
     func performTap() {
         onTap?()
+    }
+
+    @ViewBuilder var retryButton: some View {
+        if let onRetry = notice.onRetry, let retryTitle = notice.retryTitle {
+            HStack {
+                Divider()
+                    .frame(height: 16)
+
+                Button(retryTitle, action: onRetry)
+                    .padding(.horizontal, 8)
+            }
+        }
     }
 
     @ViewBuilder var icon: some View {

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -35,8 +35,11 @@ public struct NoticeView: View {
                 Divider()
                     .frame(height: 16)
 
-                Button(retryTitle, action: onRetry)
-                    .padding(.horizontal, 8)
+                Button(action: onRetry) {
+                    Text(retryTitle)
+                        .satsFont(.basic, weight: .emphasis)
+                }
+                .padding(.horizontal, 8)
             }
         }
     }

--- a/azure-devops/azure-pipelines-test.yml
+++ b/azure-devops/azure-pipelines-test.yml
@@ -33,7 +33,7 @@ jobs:
         displayName: "Workaround for private SSH SPM dependencies"
         inputs:
           targetType: "inline"
-          script: "for ip in $(dig @8.8.8.8 gitlab.com +short); do ssh-keyscan -t ecdsa github.com,$ip; done 2>/dev/null >> ~/.ssh/known_hosts"
+          script: "for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan -t ecdsa github.com,$ip; done 2>/dev/null >> ~/.ssh/known_hosts"
           failOnStderr: true
 
       - task: Xcode@5


### PR DESCRIPTION
When errors occur and we use notice, we may want to add a retry button to the error case of notices

This will be used in the new friend's profile

![Screenshot 2021-11-23 at 09 44 39](https://user-images.githubusercontent.com/167989/142993653-eec27c8b-d795-4b8f-a10f-23d5762c7557.png)

If an error has the `onRetry` parameters it won't autoDismiss.