### PR TITLE
Feature: backport modifiers

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-Types.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-Types.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+/// An internal type to encapsulate the backported types
+struct Backported {}
+
+extension Backported {
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-Types.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-Types.swift
@@ -4,4 +4,24 @@ import SwiftUI
 struct Backported {}
 
 extension Backported {
+    struct TaskModifier: ViewModifier {
+        let action: () async -> Void
+        @State var currentTask: Task<Void, Never>?
+
+        init(action: @escaping () async -> Void) {
+            self.action = action
+        }
+
+        func body(content: Content) -> some View {
+            content
+                .onAppear {
+                    currentTask = Task {
+                        await action()
+                    }
+                }
+                .onDisappear {
+                    currentTask?.cancel()
+                }
+        }
+    }
 }

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -4,3 +4,14 @@ public extension View {
     var backport: Backport<Self> { Backport(self) }
 }
 
+public extension Backport where Content: View {
+    @available(iOS, deprecated: 15, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func tint(_ color: Color?) -> some View {
+        if #available(iOS 15, *) {
+            content.tint(color)
+        } else {
+            // deprecated version
+            content.accentColor(color)
+        }
+    }
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+public extension View {
+    var backport: Backport<Self> { Backport(self) }
+}
+

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -26,4 +26,15 @@ public extension Backport where Content: View {
             content.accentColor(color)
         }
     }
+
+    @available(iOS, deprecated: 15, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func task(_ action: @escaping () async -> Void) -> some View {
+        if #available(iOS 15, *) {
+            content.task {
+                await action()
+            }
+        } else {
+            content.modifier(Backported.TaskModifier(action: action))
+        }
+    }
 }

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -6,6 +6,18 @@ public extension View {
 
 public extension Backport where Content: View {
     @available(iOS, deprecated: 15, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func searchable(
+        text: Binding<String>,
+        prompt: Text? = nil
+    ) -> some View {
+        if #available(iOS 15, *) {
+            content.searchable(text: text, placement: .navigationBarDrawer(displayMode: .always), prompt: prompt)
+        } else {
+            content
+        }
+    }
+
+    @available(iOS, deprecated: 15, message: "This is a backported version that is not neeeded anymore")
     @ViewBuilder func tint(_ color: Color?) -> some View {
         if #available(iOS 15, *) {
             content.tint(color)

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport.swift
@@ -1,0 +1,11 @@
+// taken from https://davedelong.com/blog/2021/10/09/simplifying-backwards-compatibility-in-swift/
+
+import SwiftUI
+
+public struct Backport<Content> {
+    public let content: Content
+
+    public init(_ content: Content) {
+        self.content = content
+    }
+}


### PR DESCRIPTION
I previously shared this article https://davedelong.com/blog/2021/10/09/simplifying-backwards-compatibility-in-swift/

and while working on the new booking UI I started needing support for the `.searchable` modifier which
is only available in iOS 15.

I took some of the modifiers that I did and I included them in the backport type.

Check the individual commits for details.