### PR TITLE
Destructive alert type

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
@@ -42,7 +42,6 @@ public struct AlertViewData: Identifiable, Equatable {
 
 public extension Alert {
     /// Creates an alert from view data, this include a default cancel button
-    ///
     init(viewData: AlertViewData)  {
         let primaryButton: Alert.Button
 

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewData/AlertViewData.swift
@@ -9,17 +9,20 @@ public struct AlertViewData: Identifiable, Equatable {
     public let message: String
     public let actionTitle: String
     public let action: () -> Void
+    public let actionButtonStyle: ActionButtonStyle
 
     public init(
         id: String? = nil,
         title: String,
         message: String,
+        actionButtonStyle: ActionButtonStyle = .default,
         actionTitle: String,
         action: @escaping () -> Void
     ) {
         self.id = id ?? UUID().uuidString
         self.title = title
         self.message = message
+        self.actionButtonStyle = actionButtonStyle
         self.actionTitle = actionTitle
         self.action = action
     }
@@ -30,15 +33,31 @@ public struct AlertViewData: Identifiable, Equatable {
             lhs.message == rhs.message &&
             lhs.actionTitle == rhs.actionTitle
     }
+    
+    public enum ActionButtonStyle {
+        case `default`
+        case destructive
+    }
 }
 
 public extension Alert {
     /// Creates an alert from view data, this include a default cancel button
-    init(viewData: AlertViewData) {
+    ///
+    init(viewData: AlertViewData)  {
+        let primaryButton: Alert.Button
+
+        switch viewData.actionButtonStyle {
+        case .`default`:
+            primaryButton = .default(Text(viewData.actionTitle), action: viewData.action)
+
+        case .destructive :
+            primaryButton = .destructive(Text(viewData.actionTitle), action: viewData.action)
+        }
+        
         self.init(
             title: Text(viewData.title),
             message: Text(viewData.message),
-            primaryButton: .default(Text(viewData.actionTitle), action: viewData.action),
+            primaryButton: primaryButton,
             secondaryButton: .cancel()
         )
     }


### PR DESCRIPTION
When we want the user to be clearly aware of their actions within an alert, a possibility to add a destructive typed action button could be useful. This PR adds a "ActionButtonStyle" enumeration argument to AlertViewData within the initializer. Default is default and are therefore not destroying existing declarations.

![IMG_1396](https://user-images.githubusercontent.com/9019310/157266619-b7eba5f6-c7c7-482f-905d-706127caac58.jpeg)
 