### PR TITLE
Internal: changed url scheme for fetching sats type

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "SATSType",
-        "repositoryURL": "git@github.com:healthfitnessnordic/SATSType-iOS.git",
+        "repositoryURL": "https://github.com/healthfitnessnordic/SATSType-iOS.git",
         "state": {
           "branch": null,
           "revision": "3ba28b89b06c6e241cc6615219acb94ea9cdba0e",

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(
             name: "SATSType",
-            url: "git@github.com:healthfitnessnordic/SATSType-iOS.git",
+            url: "https://github.com/healthfitnessnordic/SATSType-iOS.git",
             .upToNextMajor(from: "0.0.2")
         ),
     ],


### PR DESCRIPTION
"We’ll permanently stop accepting DSA keys. RSA keys uploaded after the cut-off point above will work only with SHA-2 signatures (but again, RSA keys uploaded before this date will continue to work with SHA-1). The deprecated MACs, ciphers, and unencrypted Git protocol will be permanently disabled." - 25.03.2022, Github ( https://github.blog/2021-09-01-improving-git-protocol-security-github/ )