### PR TITLE
Fix: make `PullToRefreshContainer` public again

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -45,7 +45,7 @@ public extension Backport where Content: View {
                 await action()
             }
         } else {
-            Backported.PullToRefreshContainer(onReload: action) {
+            PullToRefreshContainer(onReload: action) {
                 content
             }
         }

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/PullToRefreshContainer/PullToRefreshContainer.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/PullToRefreshContainer/PullToRefreshContainer.swift
@@ -1,61 +1,64 @@
 import SwiftUI
 
-extension Backported {
-    /// A custom pull-to refresh container intended to be used for iOS 14.
-    /// The content's height will be set at least to the height of the parent of this container
-    ///
-    /// Example:
-    ///
-    /// ```swift
-    /// PullToRefreshContainer(isLoading: value, onReaload: fetchData) {
-    ///     MyCustomList()
-    /// }
-    /// ```
-    @available(iOS,
-        deprecated: 15,
-        message: "This was a backport of the modifier for pull to refresh, now you should use the modifiers on list"
-    )
-    struct PullToRefreshContainer<Content: View>: View {
-        @State private var scrollValue: CGFloat = 0
-        @State private var isLoading: Bool = false
-        var onReload: () async -> Void
-        @ViewBuilder var content: Content
+/// A custom pull-to refresh container intended to be used for iOS 14.
+/// The content's height will be set at least to the height of the parent of this container
+///
+/// Example:
+///
+/// ```swift
+/// PullToRefreshContainer(isLoading: value, onReaload: fetchData) {
+///     MyCustomList()
+/// }
+/// ```
+@available(iOS,
+    deprecated: 15,
+    message: "This was a backport of the modifier for pull to refresh, now you should use the modifiers on list"
+)
+public struct PullToRefreshContainer<Content: View>: View {
+    @State private var scrollValue: CGFloat = 0
+    @State private var isLoading: Bool = false
+    var onReload: () async -> Void
+    @ViewBuilder var content: Content
 
-        private let progressHeight: CGFloat = 50
+    public init(onReload: @escaping () async -> Void, @ViewBuilder content: () -> Content) {
+        self.onReload = onReload
+        self.content = content()
+    }
 
-        public var body: some View {
-            GeometryReader { proxy in
-                ZStack {
-                    Color.clear
+    private let progressHeight: CGFloat = 50
 
-                    VStack {
-                        ProgressView()
-                            .padding()
+    public var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.clear
 
-                        Spacer()
-                    }
+                VStack {
+                    ProgressView()
+                        .padding()
 
-                    ScrollReaderView(scrollValue: $scrollValue, showsIndicators: false) {
-                        content
-                            .frame(minHeight: proxy.size.height)
-                            .offset(x: 0, y: isLoading ? progressHeight : 0)
-                    }
+                    Spacer()
+                }
+
+                ScrollReaderView(scrollValue: $scrollValue, showsIndicators: false) {
+                    content
+                        .frame(minHeight: proxy.size.height)
+                        .offset(x: 0, y: isLoading ? progressHeight : 0)
                 }
             }
-            .clipped()
-            .onChange(of: scrollValue, perform: { value in
-                if value >= progressHeight {
-                    performReload()
-                }
-            })
         }
-
-        private func performReload() {
-            isLoading = true
-            Task {
-                await onReload()
-                isLoading = false
+        .clipped()
+        .onChange(of: scrollValue, perform: { value in
+            if value >= progressHeight {
+                performReload()
             }
+        })
+    }
+
+    private func performReload() {
+        isLoading = true
+        Task {
+            await onReload()
+            isLoading = false
         }
     }
 }


### PR DESCRIPTION
This is a change i had to make because https://github.com/healthfitnessnordic/Sats-Member-App-iOS/pull/1060 was blocked by another xcode issue.

Then the app still needs a public version of this component