### PR TITLE
Internal: create PR template

### DIFF
--- a/GitHub/PULL_REQUEST_TEMPLATE.md
+++ b/GitHub/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+- Title:
+	- **Feature**: a completely new feature in the library
+	- **Improvement**: over a existing feature in the library
+	- **Fix**: bug fix either visual or logic related
+	- **Internal**: some internal improvement that users wouldn’t notice
+
+# Why?
+
+_A short description on what's the reasoning was behind these changes._
+
+# What?
+
+_A summary of what has changed and if there's anything in special that you would like feedback on._
+
+# Version Change
+
+_Is this a minor? patch? breaking change?_
+
+# UI Changes
+
+_If the change concerns UI, a transition or an animation, providing an image, a gif, or a video is encouraged to help us reviewing your PR._
+
+| Before | After |
+| --- | --- |
+| _Before image/gif_ | _After image/gif_ |
+
+_or_
+
+_demo video/gif_


### PR DESCRIPTION
Based on https://github.com/finn-no/FinniversKit/blob/master/PULL_REQUEST_TEMPLATE.md and our discussions in the iOS team

Add an initial version of the PR template.

The idea when doing a PR is to remove sections that don't apply and fill what it makes sense.

Since this is a team effort, I expect all iOS devs in the team to review/approve this PR.

Please comment if you think anything is missing or if you have suggestions