### PR TITLE
Fix: update dark mode color of graphical elements

### DIFF
--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements3.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements3.colorset/Contents.json
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.700",
+          "alpha" : "0.600",
           "blue" : "0xFF",
           "green" : "0xFF",
           "red" : "0xFF"

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements3.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements3.colorset/Contents.json
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.900",
+          "alpha" : "0.700",
           "blue" : "0xFF",
           "green" : "0xFF",
           "red" : "0xFF"


### PR DESCRIPTION
The dark mode color for graphical elements 3 does not match the design system in Figma and results in a UI which looks strange. Fixed by modifying the colors alpha channel.

| Before | After |
|:----:|:----:|
| <img src="https://user-images.githubusercontent.com/57347029/159504673-42cf33a8-6163-47a1-a0b5-aeccd930191c.PNG"> | <img src="https://user-images.githubusercontent.com/57347029/159668114-fa9cc8ff-9c89-4328-8489-5999566af0a7.PNG"> |


