### PR TITLE
Feature: corner radius

### DIFF
--- a/Sources/SATSCore/DNA/Spacings/Spacings.swift
+++ b/Sources/SATSCore/DNA/Spacings/Spacings.swift
@@ -20,9 +20,9 @@ public extension CGFloat {
 
     // MARK: Corner Radius
     /// Radius: 8
-    static let borderRadiusS: CGFloat = 8
+    static let cornerRadiusS: CGFloat = 8
     /// Radius: 12
-    static let borderRadiusS: CGFloat = 12
+    static let cornerRadiusS: CGFloat = 12
     /// Radius: 24
-    static let borderRadiusS: CGFloat = 24
+    static let cornerRadiusS: CGFloat = 24
 }

--- a/Sources/SATSCore/DNA/Spacings/Spacings.swift
+++ b/Sources/SATSCore/DNA/Spacings/Spacings.swift
@@ -17,4 +17,12 @@ public extension CGFloat {
     static let spacingXXL: CGFloat = 64
     /// spacing of 128 pts
     static let spacingXXXL: CGFloat = 128
+
+    // MARK: Corner Radius
+    /// Radius: 8
+    static let borderRadiusS: CGFloat = 8
+    /// Radius: 12
+    static let borderRadiusS: CGFloat = 12
+    /// Radius: 24
+    static let borderRadiusS: CGFloat = 24
 }

--- a/Sources/SATSCore/DNA/Spacings/Spacings.swift
+++ b/Sources/SATSCore/DNA/Spacings/Spacings.swift
@@ -19,10 +19,10 @@ public extension CGFloat {
     static let spacingXXXL: CGFloat = 128
 
     // MARK: Corner Radius
-    /// Radius: 8
+    /// radius of 8 pts
     static let cornerRadiusS: CGFloat = 8
-    /// Radius: 12
-    static let cornerRadiusS: CGFloat = 12
-    /// Radius: 24
-    static let cornerRadiusS: CGFloat = 24
+    /// radius of 12 pts
+    static let cornerRadiusM: CGFloat = 12
+    /// radius of 24 pts
+    static let cornerRadiusL: CGFloat = 24
 }

--- a/Sources/SATSCore/DNA/Spacings/Spacings.swift
+++ b/Sources/SATSCore/DNA/Spacings/Spacings.swift
@@ -19,6 +19,7 @@ public extension CGFloat {
     static let spacingXXXL: CGFloat = 128
 
     // MARK: Corner Radius
+
     /// radius of 8 pts
     static let cornerRadiusS: CGFloat = 8
     /// radius of 12 pts


### PR DESCRIPTION
[Figma link](https://www.figma.com/file/WzKCwRY09zn4rzRVfY0YvdRt/sats-ds-styles?node-id=341%3A0)

# Why?

Since we often are using rounded corners on components and cards, we need a standard for different radiuses. 

# What?

Adds three different radiuses; Small (8 pts), medium (12 pts) and large (24 pts)

# Version Change

Minor change - This change does not affect existing logic in SATS Core and SATS Member app
