### PR TITLE
Internal: add color GraphicalElements4

### DIFF
--- a/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
+++ b/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
@@ -153,7 +153,7 @@ struct ColorDemoView: View {
                 ColorDemo(name: "graphicalElements1", color: .graphicalElements1),
                 ColorDemo(name: "graphicalElements2", color: .graphicalElements2),
                 ColorDemo(name: "graphicalElements3", color: .graphicalElements3),
-                ColorDemo(name: "graphicalElements4", color: .graphicalElements3),
+                ColorDemo(name: "graphicalElements4", color: .graphicalElements4),
                 ColorDemo(name: "shimmer", color: .shimmer),
                 ColorDemo(name: "tabs", color: .tabs),
             ]

--- a/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
+++ b/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
@@ -153,6 +153,7 @@ struct ColorDemoView: View {
                 ColorDemo(name: "graphicalElements1", color: .graphicalElements1),
                 ColorDemo(name: "graphicalElements2", color: .graphicalElements2),
                 ColorDemo(name: "graphicalElements3", color: .graphicalElements3),
+                ColorDemo(name: "graphicalElements4", color: .graphicalElements3),
                 ColorDemo(name: "shimmer", color: .shimmer),
                 ColorDemo(name: "tabs", color: .tabs),
             ]

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements4.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAD",
+          "green" : "0x92",
+          "red" : "0x7D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x19"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/DNA/Colors/ColorName.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorName.swift
@@ -41,6 +41,7 @@ enum ColorName: String, CaseIterable {
     case graphicalElements1
     case graphicalElements2
     case graphicalElements3
+    case graphicalElements4
     case shimmer
     case tabs
 

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -60,6 +60,7 @@ public extension Color {
     static var graphicalElements1: Color { color(.graphicalElements1) }
     static var graphicalElements2: Color { color(.graphicalElements2) }
     static var graphicalElements3: Color { color(.graphicalElements3) }
+    static var graphicalElements4: Color { color(.graphicalElements4) }
     static var shimmer: Color { color(.shimmer) }
     static var tabs: Color { color(.tabs) }
 

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -58,6 +58,7 @@ public extension UIColor {
     static var graphicalElements1: UIColor { color(.graphicalElements1) }
     static var graphicalElements2: UIColor { color(.graphicalElements2) }
     static var graphicalElements3: UIColor { color(.graphicalElements3) }
+    static var graphicalElements4: UIColor { color(.graphicalElements4) }
     static var shimmer: UIColor { color(.shimmer) }
     static var tabs: UIColor { color(.tabs) }
 

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -60,6 +60,7 @@ class ColorsTests: XCTestCase {
             .graphicalElements1,
             .graphicalElements2,
             .graphicalElements3,
+            .graphicalElements4,
             .shimmer,
             .tabs,
 


### PR DESCRIPTION
# Why?

There is currently an issue in discover where this happens in dark mode.

<img width="392" alt="Screenshot 2022-05-11 at 10 26 05" src="https://user-images.githubusercontent.com/57347029/167804397-7815a8b8-00d3-4d63-b856-666d1ddca828.png">

# What?

Add new color graphicalElements4.

# UI Changes

This is how the icon will look with the new color.

<img width="392" alt="Screenshot 2022-05-11 at 10 29 22" src="https://user-images.githubusercontent.com/57347029/167804904-47495ba6-b4e9-48a9-a8c4-94f300296f52.png">
