### PR TITLE
Feature: calendar component for GX booking

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		28D0A16727A93846001374D2 /* DatePickerDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D0A16627A93846001374D2 /* DatePickerDemoView.swift */; };
 		9B00E27325B9AE2600533641 /* SATSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9B00E27225B9AE2600533641 /* SATSCore */; };
 		9B00E29725B9D12900533641 /* Demo.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B00E29625B9D12900533641 /* Demo.xcassets */; };
-		9B2BFBDA25B719AD00383193 /* DemoAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBD925B719AD00383193 /* DemoAppApp.swift */; };
+		9B2BFBDA25B719AD00383193 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBD925B719AD00383193 /* DemoApp.swift */; };
 		9B2BFBDC25B719AD00383193 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDB25B719AD00383193 /* ContentView.swift */; };
 		9B2BFBDE25B719AD00383193 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDD25B719AD00383193 /* Assets.xcassets */; };
 		9B2BFBE125B719AD00383193 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBE025B719AD00383193 /* Preview Assets.xcassets */; };
@@ -61,7 +61,7 @@
 		28D0A16627A93846001374D2 /* DatePickerDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDemoView.swift; sourceTree = "<group>"; };
 		9B00E29625B9D12900533641 /* Demo.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Demo.xcassets; sourceTree = "<group>"; };
 		9B2BFBD625B719AD00383193 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		9B2BFBD925B719AD00383193 /* DemoAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppApp.swift; sourceTree = "<group>"; };
+		9B2BFBD925B719AD00383193 /* DemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		9B2BFBDB25B719AD00383193 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		9B2BFBDD25B719AD00383193 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B2BFBE025B719AD00383193 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -163,7 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				9B2BFBE225B719AD00383193 /* Info.plist */,
-				9B2BFBD925B719AD00383193 /* DemoAppApp.swift */,
+				9B2BFBD925B719AD00383193 /* DemoApp.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -579,7 +579,7 @@
 				9B75EC45264B1D5300B160EF /* EmptyStateDemoView.swift in Sources */,
 				9B2BFBDC25B719AD00383193 /* ContentView.swift in Sources */,
 				9B7A4D5325D2ADA30086EA4F /* ClassSampleView.swift in Sources */,
-				9B2BFBDA25B719AD00383193 /* DemoAppApp.swift in Sources */,
+				9B2BFBDA25B719AD00383193 /* DemoApp.swift in Sources */,
 				9B7A4D5725D2B03D0086EA4F /* HeaderView.swift in Sources */,
 				9BF417182681D25B00E708FD /* ScrollReaderDemoView.swift in Sources */,
 			);

--- a/DemoApp/DemoApp/App/DemoApp.swift
+++ b/DemoApp/DemoApp/App/DemoApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 @_exported import SATSCore
 
 @main
-struct DemoAppApp: App {
+struct DemoApp: App {
     init() {
         Config.setup()
     }

--- a/DemoApp/DemoApp/Views/Components/DatePickerView/DatePickerDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/DatePickerView/DatePickerDemoView.swift
@@ -6,22 +6,36 @@ struct DatePickerDemoView: View {
     @State var showFullCalendar: Bool = false
 
     var body: some View {
-        ScrollView {
+        VStack {
             VStack {
+                Text("PT booking date picker")
+                    .font(.headline)
+
                 DatePickerView(
                     selectedDate: $selectedDate,
                     showFullCalendar: $showFullCalendar,
                     days: generatePlaceholderDays()
                 )
+            }
 
-                Rectangle()
-                    .foregroundColor(.border)
-                    .frame(height: 1)
+            Rectangle()
+                .foregroundColor(.border)
+                .frame(height: 1)
 
-                Spacer()
+            Spacer()
+
+            VStack {
+                Text("GX booking date picker")
+                    .font(.headline)
+
+                DatePickerView.HorizontalDaysList(
+                    selectedDate: $selectedDate,
+                    availableDates: generatePlaceholderDays()
+                )
             }
         }
         .background(Color.backgroundPrimary)
+        .navigationTitle("Date Picker View")
     }
 
     private func generatePlaceholderDays() -> [DatePickerViewData] {

--- a/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
+++ b/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
@@ -31,6 +31,7 @@ public class DatePickerHelper {
 
         return stringValue.prefix(1).uppercased()
     }
+
     /// Should be replaced when targeting iOS 15 with
     /// Text(date, format: .dateTime.day())
     func dateNotZeroPrefixed(date: Date) -> String {
@@ -63,7 +64,11 @@ public class DatePickerHelper {
     }
 
     func circleBackgroundColor(date: Date, selectedDate: Date) -> Color {
-        if isSameDay(date1: selectedDate, date2: date) {
+        circleBackgroundColor(date: date, isSelected: isSameDay(date1: selectedDate, date2: date))
+    }
+
+    func circleBackgroundColor(date: Date, isSelected: Bool) -> Color {
+        if isSelected {
             return .satsPrimary
         }
         if isToday(date: date) {
@@ -73,7 +78,15 @@ public class DatePickerHelper {
     }
 
     func dateTextColor(date: Date, selectedDate: Date, isActive: Bool) -> Color {
-        if isSameDay(date1: selectedDate, date2: date) {
+        dateTextColor(
+            date: date,
+            isSelected: isSameDay(date1: selectedDate, date2: date),
+            isActive: isActive
+        )
+    }
+
+    func dateTextColor(date: Date, isSelected: Bool, isActive: Bool) -> Color {
+        if isSelected {
             return .onPrimary
         }
         if isActive {
@@ -97,7 +110,7 @@ public class DatePickerHelper {
         return week
     }
 
-    private func isSameDay(date1: Date, date2: Date) -> Bool {
+    func isSameDay(date1: Date, date2: Date) -> Bool {
         calendar.isDate(date1, equalTo: date2, toGranularity: .day)
     }
 

--- a/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
+++ b/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
@@ -4,9 +4,14 @@ public class DatePickerHelper {
     public static let current: DatePickerHelper = .init()
 
     let calendar: Calendar
+    public let today: () -> Date
 
-    init(calendar: Calendar = .current) {
+    public init(
+        calendar: Calendar = .current,
+        today: @escaping () -> Date = { Date() }
+    ) {
         self.calendar = calendar
+        self.today = today
     }
 
     private lazy var weekdayFormatter: DateFormatter = {
@@ -39,7 +44,7 @@ public class DatePickerHelper {
     }
 
     func getWeekdays() -> [Date] {
-        getWeek(for: Date())
+        getWeek(for: today())
     }
 
     func getWeek(for date: Date, availableDays: [DatePickerViewData]) -> [DatePickerView.WeekViewData] {
@@ -96,7 +101,7 @@ public class DatePickerHelper {
         calendar.isDate(date1, equalTo: date2, toGranularity: .day)
     }
 
-    private func isToday(date: Date) -> Bool {
-        calendar.isDate(Date(), equalTo: date, toGranularity: .day)
+    func isToday(date: Date) -> Bool {
+        calendar.isDate(today(), equalTo: date, toGranularity: .day)
     }
 }

--- a/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
+++ b/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
@@ -9,6 +9,23 @@ public class DatePickerHelper {
         self.calendar = calendar
     }
 
+    private lazy var weekdayFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "E"
+        return dateFormatter
+    }()
+
+    func weekdayName(for date: Date) -> String {
+        let stringValue: String
+
+        if #available(iOS 15.0, *) {
+            stringValue = date.formatted(.dateTime.weekday())
+        } else {
+            stringValue = weekdayFormatter.string(from: date)
+        }
+
+        return stringValue.prefix(1).uppercased()
+    }
     /// Should be replaced when targeting iOS 15 with
     /// Text(date, format: .dateTime.day())
     func dateNotZeroPrefixed(date: Date) -> String {

--- a/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
+++ b/Sources/SATSCore/Components/DatePickerView/DatePickerHelper.swift
@@ -20,6 +20,17 @@ public class DatePickerHelper {
         return dateFormatter
     }()
 
+    private lazy var dateOnlyFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter
+    }()
+
+    /// Returns a string that is only the day/month/year components for a date
+    func dateId(for date: Date) -> String {
+        dateOnlyFormatter.string(from: date)
+    }
+
     func weekdayName(for date: Date) -> String {
         let stringValue: String
 

--- a/Sources/SATSCore/Components/DatePickerView/DatePickerView.swift
+++ b/Sources/SATSCore/Components/DatePickerView/DatePickerView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public struct DatePickerViewData: Hashable {
     public let date: Date
-    public let isActive: Bool
+    public var isActive: Bool
 
     public init(date: Date, isActive: Bool) {
         self.date = date

--- a/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
+++ b/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+extension DatePickerView {
+    /// An alternative date picker intended for a horizontal scrolling list
+    public struct HorizontalDaysList: View {
+        @Binding var selectedDate: Date
+        @State var availableDates: [DatePickerViewData]
+        let helper: DatePickerHelper
+
+        public init(
+            selectedDate: Binding<Date>,
+            availableDates: [DatePickerViewData],
+            helper: DatePickerHelper = .current
+        ) {
+            self._selectedDate = selectedDate
+            self._availableDates = .init(initialValue: availableDates)
+            self.helper = helper
+        }
+
+        public var body: some View {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: .spacingL) {
+                    ForEach(availableDates, id: \.self) { date in
+                        dayView(for: date)
+                            .onTapGesture { selectedDate = date.date }
+                    }
+                }
+                .padding(.spacingM)
+                .satsFont(.small)
+            }
+            .background(Color.backgroundPrimary)
+        }
+
+        func dayView(for viewData: DatePickerViewData) -> some View {
+            DatePickerView.WeekAndDayView(
+                viewData: viewData,
+                isSelected: helper.isSameDay(date1: viewData.date, date2: selectedDate),
+                helper: helper
+            )
+            .frame(width: 32)
+        }
+    }
+}

--- a/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
+++ b/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
@@ -19,14 +19,20 @@ extension DatePickerView {
 
         public var body: some View {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: .spacingL) {
-                    ForEach(availableDates, id: \.self) { date in
-                        dayView(for: date)
-                            .onTapGesture { selectedDate = date.date }
+                ScrollViewReader { proxy in
+                    HStack(spacing: 0) {
+                        ForEach(availableDates, id: \.self) { viewData in
+                            dayView(for: viewData)
+                                .onTapGesture { selectedDate = viewData.date }
+                                .id(helper.dateId(for: viewData.date))
+                        }
+                    }
+                    .padding(.vertical, .spacingM)
+                    .satsFont(.small)
+                    .onChange(of: selectedDate) { newValue in
+                        scroll(with: proxy, to: newValue)
                     }
                 }
-                .padding(.spacingM)
-                .satsFont(.small)
             }
             .background(Color.backgroundPrimary)
         }
@@ -37,7 +43,14 @@ extension DatePickerView {
                 isSelected: helper.isSameDay(date1: viewData.date, date2: selectedDate),
                 helper: helper
             )
-            .frame(width: 32)
+            .frame(minWidth: 32)
+            .padding(.horizontal, .spacingS)
+        }
+
+        func scroll(with proxy: ScrollViewProxy, to date: Date) {
+            withAnimation(.easeInOut) {
+                proxy.scrollTo(helper.dateId(for: date))
+            }
         }
     }
 }

--- a/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
+++ b/Sources/SATSCore/Components/DatePickerView/HorizontalDaysList/HorizontalDaysList.swift
@@ -4,7 +4,7 @@ extension DatePickerView {
     /// An alternative date picker intended for a horizontal scrolling list
     public struct HorizontalDaysList: View {
         @Binding var selectedDate: Date
-        @State var availableDates: [DatePickerViewData]
+        let availableDates: [DatePickerViewData]
         let helper: DatePickerHelper
 
         public init(
@@ -13,7 +13,7 @@ extension DatePickerView {
             helper: DatePickerHelper = .current
         ) {
             self._selectedDate = selectedDate
-            self._availableDates = .init(initialValue: availableDates)
+            self.availableDates = availableDates
             self.helper = helper
         }
 

--- a/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekAndDayView.swift
+++ b/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekAndDayView.swift
@@ -27,7 +27,7 @@ extension DatePickerView {
             DatePickerView.WeekDayLabel(name: helper.weekdayName(for: viewData.date))
         }
 
-        @ViewBuilder var dayNumber: some View {
+        var dayNumber: some View {
             DatePickerView.DayView(
                 day: helper.dateNotZeroPrefixed(date: viewData.date),
                 textColor: helper.dateTextColor(

--- a/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekAndDayView.swift
+++ b/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekAndDayView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+extension DatePickerView {
+    struct WeekAndDayView: View {
+        let viewData: DatePickerViewData
+        let isSelected: Bool
+        let helper: DatePickerHelper
+
+        init(
+            viewData: DatePickerViewData,
+            isSelected: Bool,
+            helper: DatePickerHelper = .current
+        ) {
+            self.viewData = viewData
+            self.isSelected = isSelected
+            self.helper = helper
+        }
+
+        var body: some View {
+            VStack(spacing: 0) {
+                weekDay
+                dayNumber
+            }
+        }
+
+        var weekDay: some View {
+            DatePickerView.WeekDayLabel(name: helper.weekdayName(for: viewData.date))
+        }
+
+        @ViewBuilder var dayNumber: some View {
+            DatePickerView.DayView(
+                day: helper.dateNotZeroPrefixed(date: viewData.date),
+                textColor: helper.dateTextColor(
+                    date: viewData.date,
+                    isSelected: isSelected,
+                    isActive: viewData.isActive
+                ),
+                backgroundColor: helper.circleBackgroundColor(
+                    date: viewData.date,
+                    isSelected: isSelected
+                )
+            )
+        }
+    }
+}

--- a/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekDayLabel.swift
+++ b/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekDayLabel.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension DatePickerView {
+    struct WeekDayLabel: View {
+        let name: String
+
+        var body: some View {
+            Text(name)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, .spacingXXS)
+                .satsFont(.small, weight: .emphasis)
+                .foregroundColor(.onSurfaceDisabled)
+        }
+    }
+}

--- a/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekdaysView.swift
+++ b/Sources/SATSCore/Components/DatePickerView/Subviews/DatePickerView-WeekdaysView.swift
@@ -11,21 +11,9 @@ extension DatePickerView {
         var body: some View {
             HStack(spacing: 0) {
                 ForEach(helper.getWeekdays(), id: \.self) { day in
-                        Text(weekdaySingleCharacter(date: day))
-                    .frame(maxWidth: .infinity)
+                    WeekDayLabel(name: helper.weekdayName(for: day))
                 }
             }
-            .padding(.vertical, .spacingXXS)
-            .satsFont(.small, weight: .emphasis)
-            .foregroundColor(.onSurfaceDisabled)
-        }
-
-        // Should be replaced when targeting iOS 15 with
-        // Text(date, format: .dateTime.weekday(.narrow))
-        private func weekdaySingleCharacter(date: Date) -> String {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "E"
-            return dateFormatter.string(from: date).prefix(1).uppercased()
         }
     }
 }


### PR DESCRIPTION
# Why?

The calendar component that we created was fit mostly for PT, not GX.
As the GX calendar required some special behavior.

# What?

- Add another component `DatePickerView.HorizontalDaysList` that can be used for the behavior that GX wants
- Adjust `DatePickerHelper` that allows to inject today's date for testing purposes
- Fix the DemoApp's type name

# Version Change

Minor

# UI Changes

https://user-images.githubusercontent.com/167989/170026683-cb8631cc-ffb7-49b1-a56b-e9a675fa9fe7.mp4
