### PR TITLE
Feature: onSearchFocused modifier

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -88,4 +88,13 @@ public extension Backport where Content: View {
             content
         }
     }
+
+    @available(iOS, deprecated: 15, message: "This is a backported version that is not needed anymore")
+    @ViewBuilder func onSearchFocused(perform action: (() -> Void)?) -> some View {
+        if #available(iOS 15.0, *) {
+            content.onSearchFocused(perform: action)
+        } else {
+            content
+        }
+    }
 }

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewModifiers/OnSearchFocusedModifier.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewModifiers/OnSearchFocusedModifier.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@available(iOS 15.0, *)
+public extension View {
+    /// Perform the given action when the `isSearching` environment property
+    /// changes from `false` to `true`.
+    func onSearchFocused(perform action: (() -> Void)?) -> some View {
+        self.modifier(OnSearchFocusedModifier(onSearchFocused: action))
+    }
+}
+
+@available(iOS 15.0, *)
+private struct OnSearchFocusedModifier: ViewModifier {
+    var onSearchFocused: () -> Void
+    @Environment(\.isSearching) var isSearching
+
+    init(onSearchFocused: (() -> Void)? = nil) {
+        self.onSearchFocused = onSearchFocused ?? {}
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isSearching) { isSearching in
+                guard isSearching else { return }
+                onSearchFocused()
+            }
+    }
+}


### PR DESCRIPTION
# Why?

We will want to expand the bottom sheet when the user taps on the search bar in the filters

# What?

- Add `View.onSearchFocused` modifier
- Add back-ported variant

# Version Change

minor

## Demo

This will be used in a new PR in the main app