### PR TITLE
Feature: Radio button

### DIFF
--- a/Sources/SATSCore/Components/RadioButton/RadioButton.swift
+++ b/Sources/SATSCore/Components/RadioButton/RadioButton.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+public struct RadioButton<Item: Equatable>: View {
+    let item: Item
+    let selectedItem: Item
+    
+    private var isSelected: Bool { item == selectedItem }
+    private var fill: Color { isSelected ? .onBackgroundEnabledOn : .graphicalElements1 }
+    private var lineWidth: CGFloat = 2
+    
+    public init(item: Item, selectedItem: Item) {
+        self.item = item
+        self.selectedItem = selectedItem
+    }
+    
+    public var body: some View {
+        Circle()
+            .strokeBorder(fill, lineWidth: lineWidth)
+            .frame(size: 24)
+            .if(isSelected, transform: { circle in
+                circle
+                    .overlay(
+                        Circle()
+                            .fill(fill)
+                            .padding(lineWidth * 2)
+                    )
+            })
+    }
+}
+
+struct RadioButton_Previews: PreviewProvider {
+    struct Demo: View {
+        @State private var selectedNumber = 0
+        
+        var body: some View {
+            VStack(spacing: 0) {
+                RadioButton(item: 0, selectedItem: selectedNumber)
+                RadioButton(item: 1, selectedItem: selectedNumber)
+                RadioButton(item: 2, selectedItem: selectedNumber)
+                RadioButton(item: 3, selectedItem: selectedNumber)
+            }
+        }
+    }
+    
+    static var previews: some View {
+        Demo()
+    }
+}


### PR DESCRIPTION
# Why?

The existing RadioButton in SATS MemberApp is a legacy component which also includes a text and a divider. This makes the component hard to reuse. We need a new component which is more atomic. This is required for PT booking.

# What?

Add a simple RadioButton.

Initially, I wanted the RadioButton to accept a binding for selected item so that it could update on tap.
However, I decided to omit this behaviour so that the consumer can decide the tap area and position the RadioButton where it makes sense.

# Version Change

This is a minor change.

# UI Changes

![Simulator Screen Shot - iPhone 13 Pro - 2022-06-21 at 13 05 45](https://user-images.githubusercontent.com/57347029/174786371-8a5f8865-8da8-4032-9f8d-a55218b4f8d9.png)
