### PR TITLE
Internal: Rename `retry` to `action` in the notice

### DIFF
--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -13,7 +13,7 @@ struct NoticeDemoView: View {
     @State var includeSubtitle: Bool = false
     @State var autoDismiss: Bool = true
     @State var edgeTop: Bool = true
-    @State var withRetry: Bool = false
+    @State var withAction: Bool = false
     @State var style: Style = .success
 
     var edge: Notice.Edge { edgeTop ? .top : .bottom }
@@ -43,7 +43,7 @@ struct NoticeDemoView: View {
             Toggle("Auto dismiss?", isOn: $autoDismiss)
             Toggle("Top Edge?", isOn: $edgeTop)
             if style == .error {
-                Toggle("With Retry?", isOn: $withRetry)
+                Toggle("With Action?", isOn: $withAction)
             }
 
             HStack {
@@ -84,7 +84,7 @@ struct NoticeDemoView: View {
     private func createNotice() -> Notice {
         let subtitle = includeSubtitle ? "Subtitle text" : nil
 
-        switch (style, withRetry) {
+        switch (style, withAction) {
         case (.success, _):
             return Notice.success(
                 title: "Sample success notice",
@@ -103,8 +103,8 @@ struct NoticeDemoView: View {
             return Notice.error(
                 title: "Sample error notice",
                 explanation: subtitle,
-                retryTitle: "Retry",
-                onRetry: { print("on retry!") }
+                actionTitle: "Action",
+                action: { print("on action!") }
             )
 
         case (.error, false):
@@ -140,7 +140,7 @@ struct ErrorNoticeView_Previews: PreviewProvider {
 
                 NoticeView(notice: .sampleError)
 
-                NoticeView(notice: .sampleErrorWithRetry)
+                NoticeView(notice: .sampleErrorWithAction)
             }
             .previewLayout(.sizeThatFits)
         }
@@ -152,10 +152,10 @@ extension Notice {
         title: "This is a sample error"
     )
 
-    static let sampleErrorWithRetry = Notice.error(
+    static let sampleErrorWithAction = Notice.error(
         title: "This is a sample error",
-        retryTitle: "Retry",
-        onRetry: { print("Sample") }
+        actionTitle: "Action",
+        action: { print("Sample") }
     )
 
     static let sampleSuccess = Notice.success(

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -12,8 +12,8 @@ public struct Notice {
     public let foregroundColor: Color
     public let backgroundColor: Color
     public let hapticType: UINotificationFeedbackGenerator.FeedbackType?
-    public let retryTitle: String?
-    public let onRetry: (() -> Void)?
+    public let actionTitle: String?
+    public let action: (() -> Void)?
 
     public init(
         icon: Image? = nil,
@@ -23,8 +23,8 @@ public struct Notice {
         foregroundColor: Color,
         backgroundColor: Color,
         hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil,
-        retryTitle: String? = nil,
-        onRetry: (() -> Void)? = nil
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
     ) {
         self.icon = icon
         self.title = title
@@ -33,8 +33,8 @@ public struct Notice {
         self.foregroundColor = foregroundColor
         self.backgroundColor = backgroundColor
         self.hapticType = hapticType
-        self.retryTitle = retryTitle
-        self.onRetry = onRetry
+        self.actionTitle = actionTitle
+        self.action = action
     }
 
     /// Creates an error notice data struct
@@ -61,21 +61,21 @@ public struct Notice {
         )
     }
 
-    /// Create a error notice with retry options
+    /// Create a error notice with action options
     /// - Parameters:
     ///   - title: required title of the error
     ///   - explanation: (optional) explanation of the error
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
-    ///   - retryTitle: title for the retry button
-    ///   - onRetry: callback when the try button is tapped
-    /// - Returns: returns a error `Notice` that won't autodismiss that allows to retry
+    ///   - actionTitle: title for the action button
+    ///   - action: callback when the action button is tapped
+    /// - Returns: returns a error `Notice` that won't autodismiss that allows to action
     ///            an operation that caused an error
     public static func error(
         title: String,
         explanation: String? = nil,
         includeHaptic: Bool = true,
-        retryTitle: String,
-        onRetry: @escaping () -> Void
+        actionTitle: String,
+        action: @escaping () -> Void
     ) -> Notice {
         Notice(
             icon: Image(systemName: "xmark.octagon.fill"),
@@ -85,8 +85,8 @@ public struct Notice {
             foregroundColor: .onSignal,
             backgroundColor: .signalError,
             hapticType: includeHaptic ? .error : nil,
-            retryTitle: retryTitle,
-            onRetry: onRetry
+            actionTitle: actionTitle,
+            action: action
         )
     }
 

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -14,7 +14,7 @@ public struct NoticeView: View {
             icon
             message
             Spacer()
-            retryButton
+            actionButton
         }
         .foregroundColor(notice.foregroundColor)
         .padding(16)
@@ -29,14 +29,14 @@ public struct NoticeView: View {
         onTap?()
     }
 
-    @ViewBuilder var retryButton: some View {
-        if let onRetry = notice.onRetry, let retryTitle = notice.retryTitle {
+    @ViewBuilder var actionButton: some View {
+        if let onAction = notice.action, let actionTitle = notice.actionTitle {
             HStack {
                 Divider()
                     .frame(height: 16)
 
-                Button(action: onRetry) {
-                    Text(retryTitle.uppercased())
+                Button(action: onAction) {
+                    Text(actionTitle.uppercased())
                         .satsFont(.basic, weight: .emphasis)
                 }
                 .padding(.horizontal, 8)


### PR DESCRIPTION
# Why?

To make the notice more generic and to make use of it in other cases than just where retry is applicable.

# What?

- Rename from retry to action
- This will break the member app, but I'll update everything before merging anything.

# Version Change

Breaking change