### PR TITLE
Internal: Add missing colors for graphical elements 5,6 and 7

### DIFF
--- a/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
+++ b/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
@@ -154,6 +154,9 @@ struct ColorDemoView: View {
                 ColorDemo(name: "graphicalElements2", color: .graphicalElements2),
                 ColorDemo(name: "graphicalElements3", color: .graphicalElements3),
                 ColorDemo(name: "graphicalElements4", color: .graphicalElements4),
+                ColorDemo(name: "graphicalElements5", color: .graphicalElements5),
+                ColorDemo(name: "graphicalElements6", color: .graphicalElements6),
+                ColorDemo(name: "graphicalElements7", color: .graphicalElements7),
                 ColorDemo(name: "shimmer", color: .shimmer),
                 ColorDemo(name: "tabs", color: .tabs),
             ]

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements5.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x53",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x59",
+          "green" : "0x74",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements6.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6D",
+          "green" : "0x97",
+          "red" : "0x19"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9B",
+          "green" : "0xBF",
+          "red" : "0x8B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements7.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/UI/graphicalElements7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0x4B",
+          "red" : "0x48"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB9",
+          "green" : "0x6D",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/DNA/Colors/ColorName.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorName.swift
@@ -44,6 +44,9 @@ enum ColorName: String, CaseIterable {
     case graphicalElements2
     case graphicalElements3
     case graphicalElements4
+    case graphicalElements5
+    case graphicalElements6
+    case graphicalElements7
     case shimmer
     case tabs
 

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -63,6 +63,9 @@ public extension Color {
     static var graphicalElements2: Color { color(.graphicalElements2) }
     static var graphicalElements3: Color { color(.graphicalElements3) }
     static var graphicalElements4: Color { color(.graphicalElements4) }
+    static var graphicalElements5: Color { color(.graphicalElements5) }
+    static var graphicalElements6: Color { color(.graphicalElements6) }
+    static var graphicalElements7: Color { color(.graphicalElements7) }
     static var shimmer: Color { color(.shimmer) }
     static var tabs: Color { color(.tabs) }
 

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -61,6 +61,9 @@ public extension UIColor {
     static var graphicalElements2: UIColor { color(.graphicalElements2) }
     static var graphicalElements3: UIColor { color(.graphicalElements3) }
     static var graphicalElements4: UIColor { color(.graphicalElements4) }
+    static var graphicalElements5: UIColor { color(.graphicalElements5) }
+    static var graphicalElements6: UIColor { color(.graphicalElements6) }
+    static var graphicalElements7: UIColor { color(.graphicalElements7) }
     static var shimmer: UIColor { color(.shimmer) }
     static var tabs: UIColor { color(.tabs) }
 

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -63,6 +63,9 @@ class ColorsTests: XCTestCase {
             .graphicalElements2,
             .graphicalElements3,
             .graphicalElements4,
+            .graphicalElements5,
+            .graphicalElements6,
+            .graphicalElements7,
             .shimmer,
             .tabs,
 


### PR DESCRIPTION
# Why?

Figma had colors that weren't in Core package

# What?

- Added colors for.
  - `graphicalElements5`
  - `graphicalElements6`
  - `graphicalElements7`
- Update tests

# Version Change

- Minor

# UI Changes
![Simulator Screen Shot - iPhone 13 Pro - 2022-08-24 at 09 04 16](https://user-images.githubusercontent.com/675434/186353930-0633af8a-96e3-4869-9688-c025bb26ec5f.png)

